### PR TITLE
refactor: use Vite env for news service

### DIFF
--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -43,7 +43,7 @@ class NewsService {
 
   constructor() {
     // Check if we should use dynamic data based on environment or feature flags
-    this.useDynamicData = process.env.NODE_ENV !== 'test';
+    this.useDynamicData = import.meta.env.MODE !== 'test';
   }
 
   setDynamicMode(enabled: boolean) {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -9,6 +9,8 @@ afterEach(() => {
 
 // Mock window.matchMedia
 beforeAll(() => {
+  // Ensure environment mode is set for services relying on import.meta.env.MODE
+  vi.stubEnv('MODE', 'test');
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
     value: vi.fn().mockImplementation(query => ({


### PR DESCRIPTION
## Summary
- use `import.meta.env.MODE` in `NewsService` to detect dynamic data usage
- stub Vite env mode in test setup

## Testing
- `npm run test:run` *(fails: NewsService is not defined in tests)*
- `npm run lint` *(fails: 32 errors, 27 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68a836f2e3908333b9595d6e6cac9388