### PR TITLE
Implement LRU cache for news service

### DIFF
--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -60,6 +60,10 @@ class NewsService {
 
   private addToCache(key: string, data: NewsArticle[], ttl: number = this.DEFAULT_TTL) {
     // Implement LRU-like behavior
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    }
+
     if (this.cache.size >= this.MAX_CACHE_SIZE) {
       const firstKey = this.cache.keys().next().value;
       this.cache.delete(firstKey);
@@ -204,6 +208,10 @@ class NewsService {
       // Check cache first
       const cachedEntry = this.cache.get(cacheKey);
       if (cachedEntry && this.isValidCacheEntry(cachedEntry)) {
+        // Move the accessed item to the end to mark it as recently used
+        this.cache.delete(cacheKey);
+        this.cache.set(cacheKey, cachedEntry);
+
         const responseTime = Date.now() - startTime;
         this.updateStats(responseTime, true);
         return {

--- a/src/test/services/newsServiceCache.test.ts
+++ b/src/test/services/newsServiceCache.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('@/lib/supabase', () => ({ supabase: {} }));
+import newsService from '@/services/newsService';
+
+describe('NewsService LRU cache', () => {
+  const service: any = newsService;
+  const originalMax = service.MAX_CACHE_SIZE;
+
+  beforeEach(() => {
+    newsService.clearCache();
+    service.MAX_CACHE_SIZE = 2;
+  });
+
+  afterEach(() => {
+    service.MAX_CACHE_SIZE = originalMax;
+    newsService.clearCache();
+  });
+
+  it('evicts least recently used item when limit is exceeded', async () => {
+    await newsService.getPublicNews({ search: 'a' });
+    await newsService.getPublicNews({ search: 'b' });
+
+    // Access "a" again to mark it as recently used
+    await newsService.getPublicNews({ search: 'a' });
+
+    // Add another entry to trigger eviction of "b"
+    await newsService.getPublicNews({ search: 'c' });
+
+    const keys = Array.from(service.cache.keys());
+    expect(keys).toContain(JSON.stringify({ search: 'a' }));
+    expect(keys).toContain(JSON.stringify({ search: 'c' }));
+    expect(keys).not.toContain(JSON.stringify({ search: 'b' }));
+  });
+});


### PR DESCRIPTION
## Summary
- Implement LRU cache behaviour by updating entries on access and reinsert
- Add dedicated test validating eviction of least recently used cache item

## Testing
- `npx vitest run src/test/services/newsServiceCache.test.ts`
- `npm test` *(fails: Failed to resolve import "@supabase/supabase-js" and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a836f4df2c83338e689cce93de2d9d