### PR TITLE
chore: add Supabase client dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@supabase/supabase-js": "^2.48.0",
     "@tanstack/react-query": "^5.83.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- add @supabase/supabase-js to dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fsupabase-js)*
- `npm run build` *(fails: Rollup failed to resolve import "@supabase/supabase-js" from "supabase/config.ts")*
- `npm run test:run` *(fails: Failed to resolve import "@supabase/supabase-js" from "src/hooks/useNewsSync.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68a836f65b808333a823cfeeaf70ab8f