### PR TITLE
feat: parallelize related news fetching

### DIFF
--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -306,16 +306,31 @@ class NewsService {
 
   async getRelatedNews(articleId: string, limit: number = 3): Promise<NewsArticle[]> {
     try {
-      const currentArticle = await this.getNewsById(articleId);
+      // Start fetching the current article immediately
+      const currentArticlePromise = this.getNewsById(articleId);
+
+      // Try to determine category from static data to start related news fetch in parallel
+      const staticArticle = newsArticles.find(article => article.id === articleId);
+      let relatedNewsPromise: Promise<NewsServiceResult>;
+
+      if (staticArticle) {
+        relatedNewsPromise = this.getPublicNews({
+          category: staticArticle.category,
+          limit: limit + 1,
+        });
+      } else {
+        relatedNewsPromise = currentArticlePromise.then(article => {
+          if (!article) {
+            return { success: true, data: [], total: 0, hasMore: false } as NewsServiceResult;
+          }
+          return this.getPublicNews({ category: article.category, limit: limit + 1 });
+        });
+      }
+
+      const [currentArticle, result] = await Promise.all([currentArticlePromise, relatedNewsPromise]);
+
       if (!currentArticle) return [];
 
-      const options: NewsServiceOptions = {
-        category: currentArticle.category,
-        limit: limit + 1, // Get one extra to exclude current article
-      };
-
-      const result = await this.getPublicNews(options);
-      
       return result.data
         .filter(article => article.id !== articleId)
         .slice(0, limit);


### PR DESCRIPTION
## Summary
- parallelize `getNewsById` and `getPublicNews` in `getRelatedNews`

## Testing
- `VITE_SUPABASE_URL=http://example.com VITE_SUPABASE_ANON_KEY=example npm run test:run` *(fails: createTestWrapper is not a function, NewsService is not defined)*
- `VITE_SUPABASE_URL=http://example.com VITE_SUPABASE_ANON_KEY=example NODE_ENV=test bun run measure_old.ts`
- `VITE_SUPABASE_URL=http://example.com VITE_SUPABASE_ANON_KEY=example NODE_ENV=test bun run measure.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a836f797e88333a619a76d973211f3