### PR TITLE
feat: parameterized news search and indices

### DIFF
--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -106,8 +106,11 @@ class NewsService {
         query = query.eq('category', options.category);
       }
 
-      if (options.search) {
-        query = query.or(`title.ilike.%${options.search}%,content.ilike.%${options.search}%`);
+      if (options.search?.trim()) {
+        const searchText = options.search.trim();
+        query = query
+          .textSearch('title', searchText, { type: 'websearch' })
+          .textSearch('content', searchText, { type: 'websearch' });
       }
 
       if (options.limit) {

--- a/supabase/migrations/005_add_news_text_indexes.sql
+++ b/supabase/migrations/005_add_news_text_indexes.sql
@@ -1,0 +1,3 @@
+-- Add text search indexes for news title and content
+CREATE INDEX IF NOT EXISTS idx_news_title_text_search ON news USING gin (to_tsvector('portuguese', coalesce(title, '')));
+CREATE INDEX IF NOT EXISTS idx_news_content_text_search ON news USING gin (to_tsvector('portuguese', coalesce(content, '')));


### PR DESCRIPTION
## Summary
- use Supabase textSearch for safe news queries
- add database indexes for title and content text search

## Testing
- `npm run lint` *(fails: Unexpected any...)*
- `npm run test:run` *(fails: createTestWrapper is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a836f90e308333a3d297c866e8bc60