### PR TITLE
feat: lazy load news card images

### DIFF
--- a/src/components/NewsCard.tsx
+++ b/src/components/NewsCard.tsx
@@ -9,15 +9,34 @@ interface NewsCardProps {
   readTime: string;
   views: string;
   image?: string;
+  srcSet?: string;
+  sizes?: string;
 }
 
-const NewsCard = ({ title, summary, date, category, readTime, views, image }: NewsCardProps) => {
+const NewsCard = ({
+  title,
+  summary,
+  date,
+  category,
+  readTime,
+  views,
+  image,
+  srcSet,
+  sizes = "(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw",
+}: NewsCardProps) => {
   return (
     <article className="bg-news-card hover:bg-news-card-hover border border-border rounded-lg overflow-hidden transition-all duration-300 hover:shadow-lg group cursor-pointer">
       {/* Image placeholder */}
       <div className="w-full h-48 bg-secondary flex items-center justify-center text-muted-foreground">
         {image ? (
-          <img src={image} alt={title} className="w-full h-full object-cover" />
+          <img
+            src={image}
+            alt={title}
+            className="w-full h-full object-cover"
+            loading="lazy"
+            srcSet={srcSet}
+            sizes={srcSet ? sizes : undefined}
+          />
         ) : (
           <div className="text-center">
             <div className="text-4xl mb-2">📰</div>


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to news card images
- support optional `srcSet`/`sizes` for responsive images

## Testing
- `npm run lint` *(fails: Unexpected any and react-refresh warnings)*
- `npm run test:run` *(fails: unresolved imports and failing assertions)*
- `npm run build` *(fails: Rollup failed to resolve `@supabase/supabase-js`)*
- `npx lighthouse index.html --chrome-flags="--headless --no-sandbox"` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a83e9c74f48333a09dfd316a8cd603