### PR TITLE
refactor: add cache and repository layers

### DIFF
--- a/src/services/cacheService.ts
+++ b/src/services/cacheService.ts
@@ -1,0 +1,60 @@
+export interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+/**
+ * Simple LRU cache with TTL support. Entries are stored in insertion order
+ * and refreshed when accessed to provide least-recently-used eviction.
+ */
+export default class CacheService<T> {
+  public cache = new Map<string, CacheEntry<T>>();
+  public maxSize: number;
+
+  constructor(maxSize = 100) {
+    this.maxSize = maxSize;
+  }
+
+  get(key: string): T | null {
+    const entry = this.cache.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return null;
+    }
+    // refresh order for LRU behaviour
+    this.cache.delete(key);
+    this.cache.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: string, value: T, ttl: number): void {
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.maxSize) {
+      const firstKey = this.cache.keys().next().value;
+      this.cache.delete(firstKey);
+    }
+    this.cache.set(key, { value, expiresAt: Date.now() + ttl });
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  invalidate(pattern?: string): void {
+    if (!pattern) {
+      this.clear();
+      return;
+    }
+    for (const key of Array.from(this.cache.keys())) {
+      if (key.includes(pattern)) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  size(): number {
+    return this.cache.size;
+  }
+}

--- a/src/services/newsRepository.ts
+++ b/src/services/newsRepository.ts
@@ -1,0 +1,93 @@
+import { supabase } from '../lib/supabase';
+import type { NewsArticle } from '../types/news';
+
+export interface NewsQueryOptions {
+  limit?: number;
+  offset?: number;
+  category?: string;
+  search?: string;
+  sortBy?: 'date' | 'views' | 'title';
+  sortOrder?: 'asc' | 'desc';
+}
+
+export interface NewsRepositoryResult {
+  data: NewsArticle[];
+  total: number;
+  hasMore: boolean;
+}
+
+async function getPublicNews(options: NewsQueryOptions = {}): Promise<NewsRepositoryResult> {
+  let query = supabase
+    .from('news')
+    .select('*', { count: 'exact' })
+    .eq('status', 'published')
+    .order('published_at', { ascending: false });
+
+  if (options.category) {
+    query = query.eq('category', options.category);
+  }
+
+  if (options.search?.trim()) {
+    const searchText = options.search.trim();
+    query = query
+      .textSearch('title', searchText, { type: 'websearch' })
+      .textSearch('content', searchText, { type: 'websearch' });
+  }
+
+  if (options.limit) {
+    query = query.limit(options.limit);
+  }
+
+  if (options.offset) {
+    query = query.range(options.offset, options.offset + (options.limit || 10) - 1);
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return {
+    data: data || [],
+    total: count || 0,
+    hasMore: (options.offset || 0) + (data?.length || 0) < (count || 0),
+  };
+}
+
+async function getNewsById(id: string): Promise<NewsArticle | null> {
+  const { data, error } = await supabase
+    .from('news')
+    .select('*')
+    .eq('id', id)
+    .eq('status', 'published')
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (data) {
+    await supabase
+      .from('news')
+      .update({ views: (data.views || 0) + 1 })
+      .eq('id', id);
+    data.views = (data.views || 0) + 1;
+  }
+
+  return data as NewsArticle | null;
+}
+
+async function incrementViews(id: string): Promise<boolean> {
+  const { error } = await supabase
+    .from('news')
+    .update({ views: supabase.sql('views + 1') })
+    .eq('id', id);
+  return !error;
+}
+
+export default {
+  getPublicNews,
+  getNewsById,
+  incrementViews,
+};


### PR DESCRIPTION
## Summary
- add reusable LRU cache with TTL
- move Supabase queries to a dedicated news repository
- coordinate cache and repository access via news service

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run test:run` *(fails: failed to resolve import, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a83e88575083338e97b4cc2ef523aa