### PR TITLE
docs: add architecture diagram and contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+Thank you for your interest in improving this project!
+
+## Commit Guidelines
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages.
+- Write clear, concise messages in the imperative mood (e.g., `feat: add login page`).
+
+## Development Workflow
+
+1. Install dependencies with `npm install`.
+2. Run the linter with `npm run lint` and fix any issues.
+3. Execute the test suite with `npm test`.
+4. Commit your changes once lint and tests pass.
+
+Following these steps helps maintain code quality and consistency across the project.
+

--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Architecture
+
+See [docs/architecture.md](docs/architecture.md) for a high-level diagram of the project's modules.
+
+## Contributing
+
+Guidelines for commits, linting, and tests are available in [CONTRIBUTING.md](CONTRIBUTING.md).
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,22 @@
+# Architecture
+
+This project is organized into a few key modules:
+
+```mermaid
+flowchart TB
+  subgraph UI
+    src["src/"]
+  end
+  subgraph Shared
+    shared["shared/"]
+  end
+  subgraph Backend
+    supabase["supabase/"]
+  end
+
+  src --> shared
+  src --> supabase
+```
+
+The `src/` directory contains the React application, `shared/` holds utilities and shared code, and `supabase/` defines database types and migrations.
+


### PR DESCRIPTION
## Summary
- add module diagram in docs/architecture.md
- create CONTRIBUTING.md with commit, lint, and test guidance
- reference architecture and contributing docs from README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package `globals`)*

------
https://chatgpt.com/codex/tasks/task_e_68a83f10b90c8333ba7bb0cc2e6f5bba