### PR TITLE
feat: add accessible form error alerts

### DIFF
--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -12,6 +12,7 @@ import {
 
 import { cn } from "@/lib/utils"
 import { Label } from "@/components/ui/label"
+import { Alert, AlertDescription } from "@/components/ui/alert"
 
 const Form = FormProvider
 
@@ -141,8 +142,8 @@ const FormDescription = React.forwardRef<
 FormDescription.displayName = "FormDescription"
 
 const FormMessage = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
 >(({ className, children, ...props }, ref) => {
   const { error, formMessageId } = useFormField()
   const body = error ? String(error?.message) : children
@@ -152,14 +153,17 @@ const FormMessage = React.forwardRef<
   }
 
   return (
-    <p
+    <Alert
       ref={ref}
       id={formMessageId}
-      className={cn("text-sm font-medium text-destructive", className)}
+      variant="destructive"
+      aria-live="assertive"
       {...props}
     >
-      {body}
-    </p>
+      <AlertDescription className={cn("text-sm font-medium", className)}>
+        {body}
+      </AlertDescription>
+    </Alert>
   )
 })
 FormMessage.displayName = "FormMessage"


### PR DESCRIPTION
## Summary
- use Alert component to announce form errors via aria-live
- ensure form labels reference their inputs with htmlFor

## Testing
- `npm test` (fails: sh: 1: vitest: not found)
- `npm run lint` (fails: Cannot find package '/workspace/ubanews/node_modules/globals/index.js')

------
https://chatgpt.com/codex/tasks/task_e_68a83ef6b4c48333b88ee6344e42786d