### PR TITLE
feat: secure admin operations with edge function and RLS

### DIFF
--- a/src/admin/api/adminNews.ts
+++ b/src/admin/api/adminNews.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../../../supabase/config';
+
+// Helper functions to call server-side edge function for admin news operations
+export async function createNews(data: Record<string, unknown>) {
+  return await supabase.functions.invoke('admin-news', {
+    body: { action: 'create', data }
+  });
+}
+
+export async function updateNews(id: string, data: Record<string, unknown>) {
+  return await supabase.functions.invoke('admin-news', {
+    body: { action: 'update', id, data }
+  });
+}
+
+export async function deleteNews(id: string) {
+  return await supabase.functions.invoke('admin-news', {
+    body: { action: 'delete', id }
+  });
+}

--- a/src/admin/pages/NewsForm.tsx
+++ b/src/admin/pages/NewsForm.tsx
@@ -44,6 +44,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { supabase } from '../../../supabase/config';
+import { createNews, updateNews } from '../api/adminNews';
 import { toast } from 'sonner';
 
 // Validation schema
@@ -193,11 +194,8 @@ export const NewsForm: React.FC = () => {
       };
 
       if (isEditing && id) {
-        // Update existing news
-        const { error } = await supabase
-          .from('admin_news')
-          .update(newsData)
-          .eq('id', id);
+        // Update existing news through secure edge function
+        const { error } = await updateNews(id, newsData);
 
         if (error) {
           console.error('Error updating news:', error);
@@ -207,13 +205,11 @@ export const NewsForm: React.FC = () => {
 
         toast.success('Notícia atualizada com sucesso');
       } else {
-        // Create new news
-        const { error } = await supabase
-          .from('admin_news')
-          .insert({
-            ...newsData,
-            created_at: new Date().toISOString()
-          });
+        // Create new news through secure edge function
+        const { error } = await createNews({
+          ...newsData,
+          created_at: new Date().toISOString()
+        });
 
         if (error) {
           console.error('Error creating news:', error);

--- a/src/admin/pages/NewsList.tsx
+++ b/src/admin/pages/NewsList.tsx
@@ -49,6 +49,7 @@ import {
 } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { supabase } from '../../../supabase/config';
+import { updateNews, deleteNews } from '../api/adminNews';
 import { toast } from 'sonner';
 
 interface NewsItem {
@@ -142,10 +143,7 @@ export const NewsList: React.FC = () => {
     if (!newsToDelete) return;
 
     try {
-      const { error } = await supabase
-        .from('admin_news')
-        .delete()
-        .eq('id', newsToDelete.id);
+      const { error } = await deleteNews(newsToDelete.id);
 
       if (error) {
         console.error('Error deleting news:', error);
@@ -171,10 +169,7 @@ export const NewsList: React.FC = () => {
         updateData.published_at = new Date().toISOString();
       }
 
-      const { error } = await supabase
-        .from('admin_news')
-        .update(updateData)
-        .eq('id', newsId);
+      const { error } = await updateNews(newsId, updateData);
 
       if (error) {
         console.error('Error updating news status:', error);

--- a/supabase/functions/admin-news/index.ts
+++ b/supabase/functions/admin-news/index.ts
@@ -1,0 +1,80 @@
+import { serve } from "https://deno.land/std/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+// Edge function handling administrative news operations
+// Uses service role key stored in environment variables and verifies user role
+serve(async (req: Request) => {
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405 });
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Missing authorization' }), { status: 401 });
+  }
+
+  const token = authHeader.replace('Bearer ', '');
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  );
+
+  // Verify authenticated user
+  const { data: authData, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !authData?.user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  const { data: adminUser } = await supabase
+    .from('admin_users')
+    .select('role, is_active')
+    .eq('id', authData.user.id)
+    .single();
+
+  if (!adminUser || !adminUser.is_active) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+  }
+
+  const body = await req.json();
+  const { action, id, data } = body as { action: string; id?: string; data?: Record<string, unknown> };
+
+  let result;
+  switch (action) {
+    case 'create':
+      if (!['admin', 'editor'].includes(adminUser.role)) {
+        return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+      }
+      result = await supabase.from('admin_news').insert(data);
+      break;
+    case 'update':
+      if (!id) {
+        return new Response(JSON.stringify({ error: 'Missing id' }), { status: 400 });
+      }
+      if (!['admin', 'editor'].includes(adminUser.role)) {
+        return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+      }
+      result = await supabase.from('admin_news').update(data).eq('id', id);
+      break;
+    case 'delete':
+      if (!id) {
+        return new Response(JSON.stringify({ error: 'Missing id' }), { status: 400 });
+      }
+      if (adminUser.role !== 'admin') {
+        return new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+      }
+      result = await supabase.from('admin_news').delete().eq('id', id);
+      break;
+    default:
+      return new Response(JSON.stringify({ error: 'Invalid action' }), { status: 400 });
+  }
+
+  if (result.error) {
+    return new Response(JSON.stringify({ error: result.error.message }), { status: 400 });
+  }
+
+  return new Response(JSON.stringify(result.data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  });
+});

--- a/supabase/migrations/004_add_rls_audit_logs.sql
+++ b/supabase/migrations/004_add_rls_audit_logs.sql
@@ -1,0 +1,11 @@
+-- Enable RLS on audit_logs table and restrict access
+ALTER TABLE audit_logs ENABLE ROW LEVEL SECURITY;
+
+-- Allow only admins to view audit logs
+CREATE POLICY "Admins can view audit logs" ON audit_logs
+FOR SELECT USING (
+  EXISTS (
+    SELECT 1 FROM admin_users
+    WHERE id = auth.uid() AND role = 'admin' AND is_active = true
+  )
+);


### PR DESCRIPTION
## Summary
- route admin news mutations through a Supabase Edge Function using service role key
- call edge function from admin pages instead of direct client mutations
- enable RLS with admin-only policy on audit logs table

## Testing
- `npm run lint` *(fails: Unexpected any in existing tests)*
- `npm test` *(fails: multiple failing tests and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a83ec386088333822e318a9415480c