### PR TITLE
Add RTL tests for feed filters, pagination, and login flow

### DIFF
--- a/src/components/MobileNewsFeed.tsx
+++ b/src/components/MobileNewsFeed.tsx
@@ -191,12 +191,14 @@ export const MobileNewsFeed: React.FC<MobileNewsFeedProps> = ({
     error,
     hasMore,
     refresh,
-    loadMore
+    fetchMore
   } = usePaginatedData({
     initialData: newsSource,
-    loadMore: shouldUseDynamic ? loadMoreDynamic : (onLoadMore || mockLoadMore),
+    fetchPage: shouldUseDynamic ? loadMoreDynamic : (onLoadMore || mockLoadMore),
     pageSize: 6
   });
+
+  const loadMore = fetchMore;
   
   // Combina estados de loading
   const combinedLoading = loading || isLoadingNews;
@@ -530,9 +532,9 @@ export const MobileNewsFeed: React.FC<MobileNewsFeedProps> = ({
       <div className={`
         grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6
         transition-all duration-500 ease-in-out
-        ${initialLoading ? 'opacity-0 translate-y-4' : 'opacity-100 translate-y-0'}
+        ${loadingState.initialLoading ? 'opacity-0 translate-y-4' : 'opacity-100 translate-y-0'}
       `}>
-        {!initialLoading && filteredNews.map((news, index) => (
+        {!loadingState.initialLoading && filteredNews.map((news, index) => (
           <MobileNewsCard
             key={news.id}
             {...convertToCardProps(news)}

--- a/src/test/admin/LoginPage.test.tsx
+++ b/src/test/admin/LoginPage.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from '../utils';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { LoginPage } from '@/admin/auth/LoginPage';
+import { toast } from 'sonner';
+
+const mockLogin = vi.fn();
+
+vi.mock('@/admin/context/AdminProvider', () => ({
+  useAdmin: () => ({ user: null, login: mockLogin, loading: false })
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}));
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    mockLogin.mockReset();
+    (toast.success as any).mockClear();
+    (toast.error as any).mockClear();
+  });
+
+  it('realiza login com sucesso', async () => {
+    mockLogin.mockResolvedValue({ success: true });
+
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText(/Email/i), {
+      target: { value: 'user@example.com' }
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'senha' }
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Entrar' }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith('user@example.com', 'senha');
+    });
+
+    expect(toast.success).toHaveBeenCalled();
+    expect(screen.queryByText(/Erro/)).not.toBeInTheDocument();
+  });
+
+  it('mostra erro quando login falha', async () => {
+    mockLogin.mockResolvedValue({ success: false, error: 'Credenciais inválidas' });
+
+    render(<LoginPage />);
+
+    fireEvent.change(screen.getByLabelText(/Email/i), {
+      target: { value: 'user@example.com' }
+    });
+    fireEvent.change(screen.getByLabelText(/Senha/i), {
+      target: { value: 'errada' }
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Entrar' }));
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith('user@example.com', 'errada');
+    });
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(screen.getByText('Credenciais inválidas')).toBeInTheDocument();
+  });
+});
+

--- a/src/test/components/MobileNewsFeed.test.tsx
+++ b/src/test/components/MobileNewsFeed.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from '../utils';
+import { vi, describe, it, expect } from 'vitest';
+import { MobileNewsFeed } from '@/components/MobileNewsFeed';
+import type { NewsArticle } from '@/types/news';
+
+const baseArticle: Omit<NewsArticle, 'id' | 'title' | 'category'> = {
+  date: '2024-01-01',
+  tags: [],
+  image: { src: 'img', alt: 'img', caption: 'img' },
+  excerpt: 'excerpt',
+  content: 'content',
+  readTime: 5
+};
+
+const initialData: NewsArticle[] = [
+  { ...baseArticle, id: '1', title: 'Artigo A', category: 'Gastronomia' },
+  { ...baseArticle, id: '2', title: 'Artigo B', category: 'Cultura' },
+  { ...baseArticle, id: '3', title: 'Artigo C', category: 'Turismo' }
+];
+
+const moreData: NewsArticle[] = [
+  { ...baseArticle, id: '4', title: 'Artigo D', category: 'Gastronomia' },
+  { ...baseArticle, id: '5', title: 'Artigo E', category: 'Cultura' },
+  { ...baseArticle, id: '6', title: 'Artigo F', category: 'Turismo' }
+];
+
+describe('MobileNewsFeed', () => {
+  it('filtra notícias por categoria', async () => {
+    render(<MobileNewsFeed initialData={initialData} enableDynamicData={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Artigo A')).toBeInTheDocument();
+    }, { timeout: 2000 });
+
+    // Ensure all articles are rendered
+    expect(screen.getByText('Artigo B')).toBeInTheDocument();
+    expect(screen.getByText('Artigo C')).toBeInTheDocument();
+
+    const gastronomyButton = screen.getByRole('tab', { name: 'Gastronomia' });
+    fireEvent.click(gastronomyButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Artigo A')).toBeInTheDocument();
+      expect(screen.queryByText('Artigo B')).not.toBeInTheDocument();
+      expect(screen.queryByText('Artigo C')).not.toBeInTheDocument();
+    });
+  });
+
+  it('carrega mais notícias na paginação', async () => {
+    const onLoadMore = vi.fn().mockResolvedValue(moreData);
+    render(
+      <MobileNewsFeed
+        initialData={initialData}
+        onLoadMore={onLoadMore}
+        enableDynamicData={false}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Artigo A')).toBeInTheDocument();
+    }, { timeout: 2000 });
+
+    expect(screen.getAllByRole('button', { name: /Ler artigo/i })).toHaveLength(3);
+
+    const loadMoreButton = screen.getByRole('button', { name: /Carregar mais notícias/i });
+    fireEvent.keyDown(loadMoreButton, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /Ler artigo/i })).toHaveLength(6);
+    }, { timeout: 2000 });
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add RTL tests validating MobileNewsFeed filters and pagination
- add LoginPage tests covering successful and failed logins
- fix MobileNewsFeed pagination hook and initial loading state reference

## Testing
- `npx vitest run src/test/components/MobileNewsFeed.test.tsx src/test/admin/LoginPage.test.tsx`
- `npm run test:coverage` *(fails: Cannot find dependency '@vitest/coverage-v8')*
- `npm install -D @vitest/coverage-v8` *(fails: 403 Forbidden when fetching registry)*
- `npm run test:run` *(fails: multiple existing tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68a83ed24d4c83339387698823bebf0d