### PR TITLE
feat: add supabase mock fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ To connect a domain, navigate to Project > Settings > Domains and click Connect 
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
 
+## Environment variables
+
+For production deployments, configure the following Supabase environment variables:
+
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+
+When these are not set, the application falls back to a mock Supabase client which is intended only for local development and tests.
+
 ## Architecture
 
 See [docs/architecture.md](docs/architecture.md) for a high-level diagram of the project's modules.

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,19 +1,24 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
+let supabase: SupabaseClient<Database>;
+
 if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase environment variables');
+  console.warn('Missing Supabase environment variables; using mock client');
+  supabase = createClient('https://localhost', 'anon-key');
+} else {
+  supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: true
+    }
+  });
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    autoRefreshToken: true,
-    persistSession: true,
-    detectSessionInUrl: true
-  }
-});
+export { supabase };
 
 // Database types for better TypeScript support
 export type Database = {

--- a/src/test/hooks/useNewsSync.test.tsx
+++ b/src/test/hooks/useNewsSync.test.tsx
@@ -2,16 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useNewsSync } from '@/hooks/useNewsSync';
 import { createMockNewsArticle, createMockSupabaseClient } from '../utils';
-import { supabase } from '@/lib/supabaseClient';
 
-// Mock Supabase
-vi.mock('@/lib/supabaseClient', () => {
-  return {
-    supabase: {
-      channel: vi.fn(),
-    },
-  };
-});
+const mockSupabase = createMockSupabaseClient();
+vi.mock('@/lib/supabaseClient', () => ({ supabase: mockSupabase }));
+import { supabase } from '@/lib/supabaseClient';
 
 // Mock feature flags
 vi.mock('@/lib/featureFlags', () => {

--- a/src/test/services/newsServiceCache.test.ts
+++ b/src/test/services/newsServiceCache.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createMockSupabaseClient } from '../utils';
 
-vi.mock('@/lib/supabaseClient', () => ({ supabase: {} }));
+const mockSupabase = createMockSupabaseClient();
+vi.mock('@/lib/supabaseClient', () => ({ supabase: mockSupabase }));
 import newsService from '@/services/newsService';
 
 describe('NewsService LRU cache', () => {


### PR DESCRIPTION
## Summary
- provide mock Supabase client when environment variables are missing
- update tests to work with the mocked Supabase client
- document required Supabase environment variables in README

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a8467b73d08333a9dd659755160462