### PR TITLE
Handle dynamic mode changes in news service

### DIFF
--- a/src/components/admin/MigrationControl.tsx
+++ b/src/components/admin/MigrationControl.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Settings, Database, Zap, BarChart3, AlertTriangle, CheckCircle } from 'lucide-react';
 import { useDynamicData, useProgressiveMigration, useMigrationMetrics, useFeatureFlags } from '../../hooks/useFeatureFlags';
-import newsService from '../../services/newsService';
+import NewsService from '../../services/newsService';
 
 /**
  * Componente para controle da migração progressiva
@@ -31,14 +31,14 @@ export function MigrationControl() {
     if (canMigrate) {
       await startMigration();
       // Notifica o serviço sobre a mudança
-      NewsService.onFeatureFlagChange();
+      NewsService.onFeatureFlagChange(useDynamic);
     }
   };
 
   const handleRollback = () => {
     if (canRollback) {
       rollbackMigration();
-      NewsService.onFeatureFlagChange();
+      NewsService.onFeatureFlagChange(useDynamic);
     }
   };
 

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -57,6 +57,11 @@ class NewsService {
     this.useDynamicData = enabled;
   }
 
+  onFeatureFlagChange(enabled: boolean) {
+    this.setDynamicMode(enabled);
+    this.clearCache();
+  }
+
   private getCacheKey(options: NewsServiceOptions = {}): string {
     return JSON.stringify(options);
   }

--- a/src/test/services/newsService.dynamicMode.test.ts
+++ b/src/test/services/newsService.dynamicMode.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, vi, expect } from 'vitest';
+vi.mock('@/lib/supabaseClient', () => ({ supabase: {} }));
+import NewsService from '@/services/newsService';
+
+describe('NewsService feature flag updates', () => {
+  it('updates dynamic mode and clears cache', () => {
+    const setDynamicModeSpy = vi.spyOn(NewsService, 'setDynamicMode');
+    const clearCacheSpy = vi.spyOn(NewsService, 'clearCache');
+
+    NewsService.onFeatureFlagChange(true);
+
+    expect(setDynamicModeSpy).toHaveBeenCalledWith(true);
+    expect(clearCacheSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `onFeatureFlagChange` to update dynamic mode and flush cache
- call service update from migration control feature flag toggle
- cover feature flag change behaviour in tests

## Testing
- `npm test src/test/services/newsService.dynamicMode.test.ts` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a846793dc483339408c746034ae073