### PR TITLE
feat: add news approvals table migration

### DIFF
--- a/supabase/migrations/006_create_approvals_table.sql
+++ b/supabase/migrations/006_create_approvals_table.sql
@@ -1,0 +1,14 @@
+-- Create news_approvals table
+CREATE TABLE IF NOT EXISTS news_approvals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    news_id UUID NOT NULL REFERENCES admin_news(id) ON DELETE CASCADE,
+    reviewer_id UUID REFERENCES admin_users(id),
+    status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'rejected')),
+    comments TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for news_approvals
+CREATE INDEX IF NOT EXISTS idx_news_approvals_news_id ON news_approvals(news_id);
+CREATE INDEX IF NOT EXISTS idx_news_approvals_status ON news_approvals(status);


### PR DESCRIPTION
## Summary
- add migration to create news_approvals table with indexes

## Testing
- `npm run check` *(fails: Cannot find package '@eslint/js')*
- `npm run test:run` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a85019c2e4833389b3fb32b1784d56