### PR TITLE
feat: add audit logs table migration

### DIFF
--- a/supabase/migrations/007_create_audit_logs_table.sql
+++ b/supabase/migrations/007_create_audit_logs_table.sql
@@ -1,0 +1,11 @@
+-- Create audit_logs table
+CREATE TABLE audit_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES admin_users(id),
+    action TEXT NOT NULL,
+    details JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_audit_logs_user_id ON audit_logs(user_id);
+CREATE INDEX idx_audit_logs_created_at ON audit_logs(created_at);


### PR DESCRIPTION
## Summary
- add migration to create audit_logs table with indexes

## Testing
- `npm test` (fails: vitest: not found)
- `npm install` (fails: 403 Forbidden fetching @supabase/supabase-js)

------
https://chatgpt.com/codex/tasks/task_e_68a8501ad07c833395fa7ecfb5f9adec