### PR TITLE
Add log for attempted Supabase database push

### DIFF
--- a/supabase/db_push_output.txt
+++ b/supabase/db_push_output.txt
@@ -1,0 +1,1 @@
+bash: command not found: supabase


### PR DESCRIPTION
## Summary
- capture error output when attempting `supabase db push`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8501bc78c8333905ddc895d095777