### PR TITLE
Load categories from Supabase

### DIFF
--- a/src/admin/pages/NewsForm.tsx
+++ b/src/admin/pages/NewsForm.tsx
@@ -45,6 +45,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { supabase } from '@/lib/supabaseClient';
 import { toast } from 'sonner';
+import useCategories from '@/hooks/useCategories';
 
 // Validation schema
 const newsSchema = z.object({
@@ -84,20 +85,6 @@ interface NewsItem {
   published_at?: string;
 }
 
-const categories = [
-  'Política',
-  'Economia',
-  'Esportes',
-  'Cultura',
-  'Saúde',
-  'Educação',
-  'Tecnologia',
-  'Meio Ambiente',
-  'Turismo',
-  'Segurança',
-  'Infraestrutura',
-  'Eventos'
-];
 
 export const NewsForm: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -112,6 +99,7 @@ export const NewsForm: React.FC = () => {
 
   const isEditing = Boolean(id);
   const isNewNews = !isEditing;
+  const { categories } = useCategories();
 
   const form = useForm<NewsFormData>({
     resolver: zodResolver(newsSchema),
@@ -526,8 +514,8 @@ export const NewsForm: React.FC = () => {
                           </FormControl>
                           <SelectContent>
                             {categories.map((category) => (
-                              <SelectItem key={category} value={category}>
-                                {category}
+                              <SelectItem key={category.id} value={category.name}>
+                                {category.name}
                               </SelectItem>
                             ))}
                           </SelectContent>

--- a/src/admin/pages/NewsManagement.tsx
+++ b/src/admin/pages/NewsManagement.tsx
@@ -38,6 +38,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import useCategories from '@/hooks/useCategories';
 
 // Validation Schema
 const newsSchema = z.object({
@@ -88,18 +89,7 @@ const NewsManagement: React.FC = () => {
     }
   });
 
-  const categories = [
-    'Política',
-    'Economia',
-    'Esportes',
-    'Cultura',
-    'Tecnologia',
-    'Saúde',
-    'Educação',
-    'Meio Ambiente',
-    'Turismo',
-    'Geral'
-  ];
+  const { categories: categoryOptions } = useCategories();
 
   const fetchNews = async () => {
     try {
@@ -346,9 +336,9 @@ const NewsManagement: React.FC = () => {
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {categories.map(category => (
-                      <SelectItem key={category} value={category}>
-                        {category}
+                    {categoryOptions.map(category => (
+                      <SelectItem key={category.id} value={category.name}>
+                        {category.name}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -517,9 +507,9 @@ const NewsManagement: React.FC = () => {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="all">Todas</SelectItem>
-                  {categories.map(category => (
-                    <SelectItem key={category} value={category}>
-                      {category}
+                  {categoryOptions.map(category => (
+                    <SelectItem key={category.id} value={category.name}>
+                      {category.name}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/components/AdvancedSearch.tsx
+++ b/src/components/AdvancedSearch.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { useButtonInteractions, useFormInteractions } from '@/hooks/useMicrointeractions';
 import { announceToScreenReader } from '@/utils/accessibility';
+import useCategories from '@/hooks/useCategories';
 
 interface SearchSuggestion {
   id: string;
@@ -39,9 +40,6 @@ const mockSuggestions: SearchSuggestion[] = [
   { id: '5', text: 'meio ambiente', type: 'tag', count: 98 }
 ];
 
-const categories = [
-  'Política', 'Economia', 'Esportes', 'Cultura', 'Turismo', 'Saúde', 'Educação', 'Meio Ambiente'
-];
 
 const dateFilters = [
   { label: 'Última hora', value: '1h' },
@@ -65,6 +63,7 @@ const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
   const [showFilters, setShowFilters] = useState(false);
   const [activeFilters, setActiveFilters] = useState<SearchFilter[]>([]);
   const [filteredSuggestions, setFilteredSuggestions] = useState<SearchSuggestion[]>(suggestions);
+  const { categories } = useCategories();
   
   const inputRef = useRef<HTMLInputElement>(null);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
@@ -335,16 +334,16 @@ const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
               <div className="flex flex-wrap gap-2">
                 {categories.map((category) => {
                   const filter: SearchFilter = {
-                    id: `category-${category}`,
-                    label: category,
-                    value: category,
+                    id: `category-${category.id}`,
+                    label: category.name,
+                    value: category.name,
                     type: 'category'
                   };
                   const isActive = activeFilters.some(f => f.id === filter.id);
-                  
+
                   return (
                     <Button
-                      key={category}
+                      key={category.id}
                       variant={isActive ? 'default' : 'outline'}
                       size="sm"
                       {...createButtonProps({
@@ -356,7 +355,7 @@ const AdvancedSearch: React.FC<AdvancedSearchProps> = ({
                         createButtonProps({ onClick: () => toggleFilter(filter) }).className
                       )}
                     >
-                      {category}
+                      {category.name}
                     </Button>
                   );
                 })}

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+
+export interface Category {
+  id: string;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  color: string | null;
+}
+
+export function useCategories() {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      const { data, error } = await supabase
+        .from('categories')
+        .select('id,name,description,icon,color');
+
+      if (error) {
+        setError(error.message);
+      } else {
+        setCategories(data || []);
+      }
+      setLoading(false);
+    };
+
+    fetchCategories();
+  }, []);
+
+  return { categories, loading, error };
+}
+
+export default useCategories;

--- a/supabase/migrations/006_create_categories_table.sql
+++ b/supabase/migrations/006_create_categories_table.sql
@@ -1,0 +1,16 @@
+-- Create categories table
+CREATE TABLE IF NOT EXISTS public.categories (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name VARCHAR(100) NOT NULL,
+  description TEXT,
+  icon VARCHAR(100),
+  color VARCHAR(50),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Trigger to update updated_at column
+CREATE TRIGGER update_categories_updated_at
+  BEFORE UPDATE ON public.categories
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- fetch categories from Supabase using a reusable hook
- replace hardcoded category lists with dynamic data
- add migration for categories table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a850281c6c83338135a1441692eb57