### PR TITLE
feat: integrate tiptap editor into news form

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@supabase/supabase-js": "^2.48.0",
     "@tanstack/react-query": "^5.83.0",
+    "@tiptap/react": "^2.7.0",
+    "@tiptap/starter-kit": "^2.7.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/components/ui/rich-text-editor.tsx
+++ b/src/components/ui/rich-text-editor.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect } from 'react'
+import { EditorContent, useEditor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import { cn } from '@/lib/utils'
+
+interface RichTextEditorProps {
+  value?: string
+  onChange?: (html: string) => void
+  className?: string
+}
+
+export const RichTextEditor: React.FC<RichTextEditorProps> = ({ value = '', onChange, className }) => {
+  const editor = useEditor({
+    extensions: [StarterKit],
+    content: value,
+    onUpdate({ editor }) {
+      onChange?.(editor.getHTML())
+    }
+  })
+
+  useEffect(() => {
+    if (editor && value !== editor.getHTML()) {
+      editor.commands.setContent(value)
+    }
+  }, [editor, value])
+
+  return (
+    <div
+      className={cn(
+        'min-h-[300px] w-full rounded-md border border-input bg-background p-3 text-sm ring-offset-background focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+        className
+      )}
+    >
+      <EditorContent editor={editor} className="prose prose-sm max-w-none focus:outline-none" />
+    </div>
+  )
+}
+
+export default RichTextEditor


### PR DESCRIPTION
## Summary
- add TipTap dependencies
- create reusable `RichTextEditor` component
- use rich text editor in admin news form and render HTML preview

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68a85023ab548333add0520703f99b7a