### PR TITLE
feat: add 2FA fields to admin users

### DIFF
--- a/src/admin/context/AdminProvider.tsx
+++ b/src/admin/context/AdminProvider.tsx
@@ -120,12 +120,13 @@ export const AdminProvider: React.FC<AdminProviderProps> = ({ children }) => {
       // In production, you would integrate with Supabase Auth properly
       if (password === 'admin123') {
         // Simulate successful login
+        const lastLoginAt = new Date().toISOString();
         await supabase
           .from('admin_users')
-          .update({ last_login_at: new Date().toISOString() })
+          .update({ last_login_at: lastLoginAt })
           .eq('id', adminUser.id);
 
-        setUser(adminUser);
+        setUser({ ...adminUser, last_login_at: lastLoginAt });
         return { success: true };
       } else {
         return { success: false, error: 'Credenciais inválidas' };

--- a/src/admin/pages/NewsList.tsx
+++ b/src/admin/pages/NewsList.tsx
@@ -238,7 +238,7 @@ export const NewsList: React.FC = () => {
   const canEditNews = (newsItem: NewsItem) => {
     if (user?.role === 'admin') return true;
     if (user?.role === 'editor') return true;
-    if (user?.role === 'columnist' && newsItem.author_name === user.name) return true;
+    if (user?.role === 'columnist' && newsItem.author_name === user.full_name) return true;
     return false;
   };
 

--- a/src/admin/types/admin.ts
+++ b/src/admin/types/admin.ts
@@ -2,13 +2,15 @@
 export interface User {
   id: string;
   email: string;
-  name: string;
+  full_name: string;
   role: 'admin' | 'columnist' | 'editor';
   avatar?: string;
   created_at: string;
   updated_at: string;
-  last_login?: string;
+  last_login_at?: string;
   is_active: boolean;
+  two_factor_enabled: boolean;
+  two_factor_secret?: string;
   permissions: Permission[];
 }
 

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -33,8 +33,10 @@ export type Database = {
           avatar: string | null;
           created_at: string;
           updated_at: string;
-          last_login: string | null;
+          last_login_at: string | null;
           is_active: boolean;
+          two_factor_enabled: boolean;
+          two_factor_secret: string | null;
         };
         Insert: {
           id?: string;
@@ -44,8 +46,10 @@ export type Database = {
           avatar?: string | null;
           created_at?: string;
           updated_at?: string;
-          last_login?: string | null;
+          last_login_at?: string | null;
           is_active?: boolean;
+          two_factor_enabled?: boolean;
+          two_factor_secret?: string | null;
         };
         Update: {
           id?: string;
@@ -55,8 +59,10 @@ export type Database = {
           avatar?: string | null;
           created_at?: string;
           updated_at?: string;
-          last_login?: string | null;
+          last_login_at?: string | null;
           is_active?: boolean;
+          two_factor_enabled?: boolean;
+          two_factor_secret?: string | null;
         };
       };
       admin_news: {

--- a/supabase/migrations/008_update_admin_users_last_login_two_factor.sql
+++ b/supabase/migrations/008_update_admin_users_last_login_two_factor.sql
@@ -1,0 +1,19 @@
+-- Ensure admin_users has last_login_at and two-factor columns
+ALTER TABLE admin_users
+  ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN IF NOT EXISTS two_factor_enabled BOOLEAN DEFAULT false,
+  ADD COLUMN IF NOT EXISTS two_factor_secret VARCHAR(255);
+
+-- Migrate data from legacy last_login column if present
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'admin_users' AND column_name = 'last_login'
+  ) THEN
+    UPDATE admin_users
+      SET last_login_at = last_login
+      WHERE last_login_at IS NULL;
+    ALTER TABLE admin_users DROP COLUMN last_login;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- track 2FA status and secrets for admin users
- use `last_login_at` instead of `last_login`
- add migration to backfill `last_login_at`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '/workspace/ubanews/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a863c3cd1883338b96ebe38191bc6f