### PR TITLE
feat: add storybook and focus-visible styles

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,15 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+
+const config: StorybookConfig = {
+  stories: ["../src/components/**/*.stories.@(ts|tsx)", "../src/**/*.stories.@(ts|tsx)"],
+  addons: ["@storybook/addon-essentials"],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+  docs: {
+    autodocs: "tag",
+  },
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,16 @@
+import type { Preview } from "@storybook/react";
+import "../src/index.css";
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: "^on[A-Z].*" },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This project is built with:
 - React
 - shadcn-ui
 - Tailwind CSS
+- Storybook
 
 ## How can I deploy this project?
 
@@ -88,4 +89,20 @@ See [docs/architecture.md](docs/architecture.md) for a high-level diagram of the
 ## Contributing
 
 Guidelines for commits, linting, and tests are available in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Storybook
+
+This project exposes its Tailwind + Radix UI component library through [Storybook](https://storybook.js.org/).
+
+Run the documentation site locally:
+
+```sh
+npm run storybook
+```
+
+Build the static documentation output:
+
+```sh
+npm run build-storybook
+```
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest --watch",
-    "check": "npm run lint && npm run test:run"
+    "check": "npm run lint && npm run test:run",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -81,6 +83,9 @@
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
+    "@storybook/addon-essentials": "^8.4.4",
+    "@storybook/react": "^8.4.4",
+    "@storybook/react-vite": "^8.4.4",
     "@vitejs/plugin-react-swc": "^3.11.0",
     "@vitest/ui": "^3.2.4",
     "autoprefixer": "^10.4.21",
@@ -96,6 +101,7 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19",
+    "storybook": "^8.4.4",
     "vitest": "^3.2.4"
   }
 }

--- a/src/components/ui/button.stories.tsx
+++ b/src/components/ui/button.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "./button";
+
+const meta: Meta<typeof Button> = {
+  title: "Components/Button",
+  component: Button,
+  args: { children: "Button" },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {};
+
+export const Outline: Story = {
+  args: { variant: "outline", children: "Outline" },
+};

--- a/src/index.css
+++ b/src/index.css
@@ -116,4 +116,7 @@ All colors MUST be HSL.
   body {
     @apply bg-background text-foreground;
   }
+  :focus-visible {
+    @apply outline-none ring-2 ring-ring ring-offset-2;
+  }
 }


### PR DESCRIPTION
## Summary
- set up Storybook for the Tailwind/Radix component library
- document Storybook usage and scripts
- add global focus-visible ring for accessible focus states

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86b7033748333ac9b37f7f7a0f2e4