### PR TITLE
test: add coverage for admin routes and preload hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ This project is built with:
 
 Simply open [Lovable](https://lovable.dev/projects/0618b2c6-61f2-4963-86c2-477715e1c918) and click on Share -> Publish.
 
+## Testing
+
+Run the unit test suite:
+
+```sh
+npm test
+```
+
+Generate a coverage report:
+
+```sh
+npm run test:coverage
+```
+
+## Local deployment
+
+To create and preview a production build locally:
+
+```sh
+npm run build
+npm run preview
+```
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/src/test/admin/ProtectedRoute.test.tsx
+++ b/src/test/admin/ProtectedRoute.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import ProtectedRoute from '@/admin/auth/ProtectedRoute';
+import { useAdmin } from '@/admin/context/AdminProvider';
+
+vi.mock('@/admin/context/AdminProvider', () => ({
+  useAdmin: vi.fn()
+}));
+
+const mockedUseAdmin = useAdmin as unknown as ReturnType<typeof vi.fn>;
+
+const renderWithRoutes = () => {
+  return render(
+    <MemoryRouter initialEntries={['/protected']}>
+      <Routes>
+        <Route
+          path="/protected"
+          element={
+            <ProtectedRoute requiredRole="admin">
+              <div>Conteúdo Seguro</div>
+            </ProtectedRoute>
+          }
+        />
+        <Route path="/admin/login" element={<div>Página de Login</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exibe carregamento enquanto verifica autenticação', () => {
+    mockedUseAdmin.mockReturnValue({ user: null, loading: true });
+    renderWithRoutes();
+    expect(screen.getByText('Verificando autenticação...')).toBeInTheDocument();
+  });
+
+  it('redireciona usuários não autenticados para login', () => {
+    mockedUseAdmin.mockReturnValue({ user: null, loading: false });
+    renderWithRoutes();
+    expect(screen.getByText('Página de Login')).toBeInTheDocument();
+  });
+
+  it('bloqueia acesso quando usuário não possui permissão', () => {
+    mockedUseAdmin.mockReturnValue({ user: { role: 'editor' }, loading: false, logout: vi.fn() });
+    renderWithRoutes();
+    expect(screen.getByText('Acesso Negado')).toBeInTheDocument();
+  });
+
+  it('renderiza conteúdo quando usuário possui permissão', () => {
+    mockedUseAdmin.mockReturnValue({ user: { role: 'admin' }, loading: false, logout: vi.fn() });
+    renderWithRoutes();
+    expect(screen.getByText('Conteúdo Seguro')).toBeInTheDocument();
+  });
+});
+

--- a/src/test/hooks/useResourcePreload.test.tsx
+++ b/src/test/hooks/useResourcePreload.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useResourcePreload } from '@/hooks/useResourcePreload';
+
+const triggerLoad = (element: HTMLLinkElement) => {
+  setTimeout(() => element.onload && element.onload(new Event('load') as any));
+};
+
+describe('useResourcePreload', () => {
+  let appendSpy: any;
+
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    appendSpy = vi.spyOn(document.head, 'appendChild').mockImplementation((el: any) => {
+      triggerLoad(el);
+      return el;
+    });
+  });
+
+  afterEach(() => {
+    appendSpy.mockRestore();
+  });
+
+  it('preloads imagem e atualiza estado', async () => {
+    const { result } = renderHook(() => useResourcePreload());
+    await act(async () => {
+      await result.current.preloadImage('/teste.png');
+    });
+
+    expect(appendSpy).toHaveBeenCalled();
+    expect(result.current.preloadedResources).toContain('image:/teste.png');
+  });
+
+  it('evita preload duplicado', async () => {
+    const { result } = renderHook(() => useResourcePreload());
+    await act(async () => {
+      await result.current.preloadImage('/teste.png');
+      await result.current.preloadImage('/teste.png');
+    });
+
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for ProtectedRoute access control
- add coverage for resource preload hook
- document test and deployment commands in README

## Testing
- `npm run test:coverage` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86add0dd4833380d8984c46e6608c