### PR TITLE
feat: add accessible alert animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "date-fns": "^3.6.0",
     "dompurify": "^3.0.0",
     "embla-carousel-react": "^8.6.0",
+    "framer-motion": "^10.16.8",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",

--- a/src/components/ui/live-alert.tsx
+++ b/src/components/ui/live-alert.tsx
@@ -1,0 +1,35 @@
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { AnimatePresence, motion } from "framer-motion"
+import { CheckCircle, AlertCircle } from "lucide-react"
+
+interface LiveAlertProps {
+  message: string
+  type: "success" | "error" | null
+}
+
+export function LiveAlert({ message, type }: LiveAlertProps) {
+  return (
+    <AnimatePresence>
+      {type && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.3 }}
+        >
+          <Alert
+            variant={type === "error" ? "destructive" : "default"}
+            aria-live={type === "error" ? "assertive" : "polite"}
+          >
+            {type === "error" ? (
+              <AlertCircle className="h-4 w-4" />
+            ) : (
+              <CheckCircle className="h-4 w-4" />
+            )}
+            <AlertDescription>{message}</AlertDescription>
+          </Alert>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import MobileHeader from '../components/MobileHeader';
 import Footer from '../components/Footer';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -8,8 +8,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { LiveAlert } from '@/components/ui/live-alert';
 import { Mail, Phone, MapPin, Send, Clock, CheckCircle, AlertCircle } from 'lucide-react';
-import { toast } from 'sonner';
 
 interface FormData {
   name: string;
@@ -27,6 +27,14 @@ const Contact: React.FC = () => {
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<Partial<FormData>>({});
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+  useEffect(() => {
+    if (feedback) {
+      const timer = setTimeout(() => setFeedback(null), 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [feedback]);
 
   const contactInfo = [
     {
@@ -83,7 +91,7 @@ const Contact: React.FC = () => {
     e.preventDefault();
 
     if (!validateForm()) {
-      toast.error("Por favor, corrija os erros no formulário");
+      setFeedback({ type: 'error', message: 'Por favor, corrija os erros no formulário' });
       return;
     }
 
@@ -92,9 +100,10 @@ const Contact: React.FC = () => {
     try {
       // Simular envio do formulário
       await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      toast.success("Mensagem enviada com sucesso!", {
-        description: "Responderemos em até 24 horas."
+
+      setFeedback({
+        type: 'success',
+        message: 'Mensagem enviada com sucesso! Responderemos em até 24 horas.',
       });
 
       setFormData({
@@ -105,8 +114,9 @@ const Contact: React.FC = () => {
       });
       setErrors({});
     } catch (error) {
-      toast.error("Erro ao enviar mensagem", {
-        description: "Por favor, tente novamente ou use outro meio de contato."
+      setFeedback({
+        type: 'error',
+        message: 'Erro ao enviar mensagem. Por favor, tente novamente ou use outro meio de contato.',
       });
     } finally {
       setIsSubmitting(false);
@@ -134,11 +144,13 @@ const Contact: React.FC = () => {
               Fale Conosco
             </h1>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto leading-relaxed">
-              Sua opinião é fundamental para melhorar nosso jornalismo. 
+              Sua opinião é fundamental para melhorar nosso jornalismo.
               Estamos aqui para ouvir e ajudar.
             </p>
           </div>
         </section>
+
+        <LiveAlert message={feedback?.message ?? ''} type={feedback?.type ?? null} />
 
         <div className="grid lg:grid-cols-3 gap-8">
           {/* Contact Form */}


### PR DESCRIPTION
## Summary
- add framer-motion for smooth alert animations
- show realtime success/error feedback on contact form with accessible alerts

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: eslint: not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a86b709a3883338a983b242e6ec7cc