### PR TITLE
chore: add accessibility tests and audits

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,19 @@
+name: Lighthouse CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
+      - run: npx lhci autorun

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,14 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "numberOfRuns": 1
+    },
+    "assert": {
+      "preset": "lighthouse:recommended"
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest --watch",
-    "check": "npm run lint && npm run test:run"
+    "lhci": "lhci autorun",
+    "check": "npm run lint && npm run test:run && npm run lhci"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -96,6 +97,8 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "vitest-axe": "^0.3.0",
+    "@lhci/cli": "^0.11.0"
   }
 }

--- a/src/test/a11y/ThemeToggle.a11y.test.tsx
+++ b/src/test/a11y/ThemeToggle.a11y.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '../utils';
+import { ThemeToggle } from '@/components/ThemeToggle';
+import { axe } from 'vitest-axe';
+import { describe, it, expect } from 'vitest';
+
+describe('ThemeToggle accessibility', () => {
+  it('has no accessibility violations', async () => {
+    const { container } = render(<ThemeToggle />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,9 @@
 import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
-import { afterEach, beforeAll, vi } from 'vitest';
+import { afterEach, beforeAll, expect, vi } from 'vitest';
+import { toHaveNoViolations } from 'vitest-axe';
+
+expect.extend(toHaveNoViolations);
 
 // Cleanup after each test case
 afterEach(() => {


### PR DESCRIPTION
## Summary
- add vitest-axe for accessibility testing
- run lighthouse CI audits via workflow
- fix HTML language attribute

## Testing
- `npm test` *(fails: vitest: not found)*
- `npx lhci autorun` *(fails: 403 Forbidden fetching lhci)*

------
https://chatgpt.com/codex/tasks/task_e_68a86b7284f88333b753acb4879b30de