### PR TITLE
test: add route and hook integration tests

### DIFF
--- a/e2e/admin-flow.spec.ts
+++ b/e2e/admin-flow.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('admin login page loads', async ({ page }) => {
+  await page.goto('/admin/login');
+  await expect(page.locator('h1, h2, h3')).toContainText(/login/i);
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest --watch",
-    "check": "npm run lint && npm run test:run"
+    "check": "npm run lint && npm run test:run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -96,6 +97,7 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@playwright/test": "^1.48.2"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+  },
+});

--- a/src/test/hooks/usePaginatedData.test.tsx
+++ b/src/test/hooks/usePaginatedData.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { usePaginatedData } from '@/hooks/use-infinite-scroll';
+
+describe('usePaginatedData', () => {
+  it('loads and paginates data correctly', async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 1 }, { id: 2 }])
+      .mockResolvedValueOnce([{ id: 3 }, { id: 4 }]);
+
+    const { result } = renderHook(() =>
+      usePaginatedData<{ id: number }>({ fetchPage, pageSize: 2 })
+    );
+
+    await waitFor(() => expect(result.current.data.length).toBe(2));
+    expect(fetchPage).toHaveBeenCalledWith(1, 2);
+
+    await act(async () => {
+      await result.current.fetchMore();
+    });
+
+    expect(fetchPage).toHaveBeenCalledWith(2, 2);
+    expect(result.current.data.length).toBe(4);
+  });
+
+  it('refresh resets state', async () => {
+    const fetchPage = vi.fn().mockResolvedValue([{ id: 1 }, { id: 2 }]);
+
+    const { result } = renderHook(() =>
+      usePaginatedData<{ id: number }>({ fetchPage, pageSize: 2 })
+    );
+
+    await waitFor(() => expect(result.current.data.length).toBe(2));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+    expect(result.current.data.length).toBe(2);
+    expect(result.current.hasMore).toBe(true);
+  });
+});

--- a/src/test/routes/ProtectedRoute.test.tsx
+++ b/src/test/routes/ProtectedRoute.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ProtectedRoute } from '@/admin/auth/ProtectedRoute';
+
+const mockUseAdmin = vi.fn();
+vi.mock('@/admin/context/AdminProvider', () => ({
+  useAdmin: () => mockUseAdmin(),
+}));
+
+const renderWithClient = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  );
+};
+
+describe('ProtectedRoute integration', () => {
+  it('redirects unauthenticated users to login', () => {
+    mockUseAdmin.mockReturnValue({ user: null, loading: false });
+
+    renderWithClient(
+      <MemoryRouter initialEntries={["/admin/dashboard"]}>
+        <Routes>
+          <Route
+            path="/admin/dashboard"
+            element={
+              <ProtectedRoute>
+                <div>Dashboard Content</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/admin/login" element={<div>Login Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+  });
+
+  it('allows access for authenticated users', () => {
+    mockUseAdmin.mockReturnValue({ user: { role: 'admin' }, loading: false, logout: vi.fn() });
+
+    renderWithClient(
+      <MemoryRouter initialEntries={["/admin/dashboard"]}>
+        <Routes>
+          <Route
+            path="/admin/dashboard"
+            element={
+              <ProtectedRoute>
+                <div>Dashboard Content</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/admin/login" element={<div>Login Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Dashboard Content')).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,7 +19,11 @@ export default defineConfig({
         '**/*.config.*',
         'dist/',
         'build/'
-      ]
+      ],
+      lines: 90,
+      functions: 90,
+      branches: 90,
+      statements: 90
     }
   },
   resolve: {


### PR DESCRIPTION
## Summary
- add route guard tests
- add pagination hook tests
- set up Playwright with admin login spec and coverage thresholds

## Testing
- `npx vitest run src/test/routes/ProtectedRoute.test.tsx src/test/hooks/usePaginatedData.test.tsx`
- `npm run test` *(fails: ReferenceError and assertion errors in existing suite)*
- `npm run test:coverage` *(fails: Cannot find dependency '@vitest/coverage-v8')*
- `npm run test:e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86b74f550833380325bf204342f08