### PR TITLE
docs: add setup, architecture and contribution guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,15 @@
 
 Thank you for your interest in improving this project!
 
+## Getting started
+
+1. Fork the repository and clone your fork.
+2. Create a feature branch from `main`:
+
+   ```sh
+   git checkout -b feat/my-feature
+   ```
+
 ## Commit Guidelines
 
 - Use [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages.
@@ -13,6 +22,13 @@ Thank you for your interest in improving this project!
 2. Run the linter with `npm run lint` and fix any issues.
 3. Execute the test suite with `npm test`.
 4. Commit your changes once lint and tests pass.
+5. Push your branch and open a pull request against `main`.
+
+## Pull requests
+
+- Include a clear description of the changes and any relevant screenshots or references.
+- Ensure all GitHub checks pass before requesting a review.
+- Small, focused pull requests are easier to review and merge.
 
 Following these steps helps maintain code quality and consistency across the project.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,43 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Local setup
+
+To run the project locally you will need a recent version of Node.js and npm. Once those are installed:
+
+1. Clone the repository and install dependencies:
+
+   ```sh
+   git clone <YOUR_GIT_URL>
+   cd <YOUR_PROJECT_NAME>
+   npm install
+   ```
+
+2. Create a `.env` file in the project root and define the environment variables listed below.
+
+3. Start the development server:
+
+   ```sh
+   npm run dev
+   ```
+
+The application will be available at `http://localhost:5173` by default.
+
+## Available scripts
+
+The following npm scripts are available:
+
+| Script | Description |
+| ------ | ----------- |
+| `npm run dev` | Start the Vite development server with hot reloading. |
+| `npm run build` | Create a production build. |
+| `npm run build:dev` | Build using the development configuration. |
+| `npm run preview` | Preview the production build locally. |
+| `npm run lint` | Run ESLint on the codebase. |
+| `npm test` | Run the test suite with Vitest. |
+| `npm run test:coverage` | Run tests and generate a coverage report. |
+| `npm run check` | Run linting and tests in a single command. |
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/0618b2c6-61f2-4963-86c2-477715e1c918) and click on Share -> Publish.
@@ -74,12 +111,14 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 
 ## Environment variables
 
-For production deployments, configure the following Supabase environment variables:
+The app expects the following Supabase environment variables to be defined in a `.env` file:
 
-- `VITE_SUPABASE_URL`
-- `VITE_SUPABASE_ANON_KEY`
+```
+VITE_SUPABASE_URL=<your-supabase-project-url>
+VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+```
 
-When these are not set, the application falls back to a mock Supabase client which is intended only for local development and tests.
+When these variables are not provided the application falls back to a mock Supabase client which is intended only for local development and tests.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,3 +20,15 @@ flowchart TB
 
 The `src/` directory contains the React application, `shared/` holds utilities and shared code, and `supabase/` defines database types and migrations.
 
+On a high level, the runtime architecture looks like this:
+
+```mermaid
+flowchart LR
+  user((Browser)) --> app[React App]
+  app --> api[Supabase Client]
+  api --> db[(Postgres DB)]
+  shared[Shared Utilities] --> app
+  shared --> api
+```
+
+User interactions go through the React application, which uses the Supabase client to communicate with the hosted Postgres database. Utility functions in `shared/` are imported by both the application and the client code to keep logic consistent across the stack.


### PR DESCRIPTION
## Summary
- document local setup, npm scripts, and environment variables in README
- add runtime architecture diagram and explanation
- expand contribution guidelines with branching and PR steps

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86b7511a88333a6f60a4408608300