### PR TITLE
feat: add security headers middleware

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,39 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import path from 'path'
+import { randomBytes } from 'node:crypto'
+
+function securityHeaders() {
+  const nonceMap = new Map<string, string>()
+  return {
+    name: 'security-headers',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const nonce = randomBytes(16).toString('base64')
+        res.setHeader(
+          'Content-Security-Policy',
+          `default-src 'self'; script-src 'self' 'nonce-${nonce}'; object-src 'none'; base-uri 'self'`
+        )
+        res.setHeader(
+          'Strict-Transport-Security',
+          'max-age=63072000; includeSubDomains; preload'
+        )
+        res.setHeader('X-Content-Type-Options', 'nosniff')
+        nonceMap.set(req.originalUrl, nonce)
+        res.on('finish', () => nonceMap.delete(req.originalUrl))
+        next()
+      })
+    },
+    transformIndexHtml(html: string, ctx) {
+      const nonce = nonceMap.get(ctx.originalUrl || ctx.path)
+      return nonce ? html.replace(/<script/gi, `<script nonce="${nonce}"`) : html
+    },
+  }
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), securityHeaders()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- enforce security headers via custom Vite middleware
- inject nonce into scripts and set CSP, HSTS and nosniff headers

## Testing
- `npm run lint` (fails: unexpected any etc.)
- `npm test -- --run` (fails: module mocking errors and failing tests)


------
https://chatgpt.com/codex/tasks/task_e_68a86b7902e48333a92ee25ef8ca75ac