### PR TITLE
chore: add bundle analyzer and optimize chunks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "date-fns": "^3.6.0",
         "dompurify": "^3.0.0",
         "embla-carousel-react": "^8.6.0",
         "input-otp": "^1.4.2",
@@ -4894,16 +4893,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",
+    "build:analyze": "ANALYZE=true vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
@@ -52,7 +53,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "date-fns": "^3.6.0",
     "dompurify": "^3.0.0",
     "embla-carousel-react": "^8.6.0",
     "input-otp": "^1.4.2",
@@ -96,6 +96,7 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "vite-bundle-analyzer": "^0.8.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { useEffect, lazy, Suspense } from "react";
 import Index from "./pages/Index";
-import NewsPage from "./pages/NewsPage";
 import {
   SearchResultsLazy,
   NotFoundLazy,
@@ -17,8 +16,9 @@ import {
   TermsOfUseLazy,
   LoadingSpinner
 } from "./components/LazyComponents";
-import WebVitalsDashboard from "./components/WebVitalsDashboard";
-import ServiceWorkerManager from "./components/ServiceWorkerUpdate";
+const NewsPage = lazy(() => import("./pages/NewsPage"));
+const WebVitalsDashboard = lazy(() => import("./components/WebVitalsDashboard"));
+const ServiceWorkerManager = lazy(() => import("./components/ServiceWorkerUpdate"));
 import ErrorBoundary from "./components/ErrorBoundary";
 import { initWebVitals, monitorResourceLoading } from "./utils/webVitals";
 import { useServiceWorker } from "./hooks/useServiceWorker";
@@ -99,7 +99,14 @@ const App = () => {
                   {/* Public routes */}
                   <Route path="/" element={<Index />} />
                   <Route path="/login" element={<Navigate to="/admin/login" replace />} />
-                  <Route path="/news/:id" element={<NewsPage />} />
+                  <Route
+                    path="/news/:id"
+                    element={
+                      <Suspense fallback={<LoadingSpinner message="Carregando notícia..." />}>
+                        <NewsPage />
+                      </Suspense>
+                    }
+                  />
                   <Route path="/search" element={<SearchResultsLazy />} />
                   <Route path="/about" element={<AboutLazy />} />
                   <Route path="/contact" element={<ContactLazy />} />
@@ -147,10 +154,12 @@ const App = () => {
                   <Route path="*" element={<NotFoundLazy />} />
                 </Routes>
               </ErrorBoundary>
-              {/* Web Vitals Dashboard - only visible in development or when debug=true */}
-              <WebVitalsDashboard />
-              {/* Service Worker Manager - handles updates and network status */}
-              <ServiceWorkerManager />
+              <Suspense fallback={null}>
+                {/* Web Vitals Dashboard - only visible in development or when debug=true */}
+                <WebVitalsDashboard />
+                {/* Service Worker Manager - handles updates and network status */}
+                <ServiceWorkerManager />
+              </Suspense>
             </BrowserRouter>
           </TooltipProvider>
         </ThemeProvider>

--- a/src/admin/pages/AdminDashboard.tsx
+++ b/src/admin/pages/AdminDashboard.tsx
@@ -34,8 +34,6 @@ import {
 } from 'lucide-react';
 import { DashboardStats } from '../types/admin';
 import { supabase } from '@/lib/supabaseClient';
-import { format, subDays, startOfDay, endOfDay } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
 
 interface ChartData {
   name: string;
@@ -97,10 +95,11 @@ const AdminDashboard: React.FC = () => {
 
         // Prepare chart data
         const last7Days = Array.from({ length: 7 }, (_, i) => {
-          const date = subDays(new Date(), i);
+          const date = new Date();
+          date.setDate(date.getDate() - i);
           return {
-            name: format(date, 'dd/MM', { locale: ptBR }),
-            date: format(date, 'yyyy-MM-dd'),
+            name: date.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' }),
+            date: date.toISOString().split('T')[0],
             value: 0
           };
         }).reverse();
@@ -108,7 +107,7 @@ const AdminDashboard: React.FC = () => {
         // News per day (last 7 days)
         const newsPerDay = last7Days.map(day => {
           const dayNews = newsResult.data.filter(news => {
-            const newsDate = format(new Date(news.created_at), 'yyyy-MM-dd');
+            const newsDate = new Date(news.created_at).toISOString().split('T')[0];
             return newsDate === day.date;
           });
           return {
@@ -220,7 +219,7 @@ const AdminDashboard: React.FC = () => {
         <div className="flex items-center space-x-2">
           <Badge variant="outline" className="text-xs">
             <Clock className="w-3 h-3 mr-1" />
-            Atualizado {format(lastUpdate, 'HH:mm', { locale: ptBR })}
+            Atualizado {lastUpdate.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}
           </Badge>
           <Button onClick={fetchDashboardData} variant="outline" size="sm">
             <RefreshCw className="w-4 h-4 mr-2" />

--- a/src/admin/pages/NewsManagement.tsx
+++ b/src/admin/pages/NewsManagement.tsx
@@ -31,8 +31,6 @@ import {
 } from 'lucide-react';
 import { AdminNews, NewsFilters, PaginationInfo } from '../types/admin';
 import { supabase } from '@/lib/supabaseClient';
-import { format } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
 import { z } from 'zod';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -257,7 +255,7 @@ const NewsManagement: React.FC = () => {
       tags: Array.isArray(newsItem.tags) ? newsItem.tags.join(', ') : '',
       featured_image: newsItem.featured_image || '',
       status: newsItem.status,
-      publish_date: newsItem.publish_date ? format(new Date(newsItem.publish_date), 'yyyy-MM-dd\'T\'HH:mm') : ''
+      publish_date: newsItem.publish_date ? new Date(newsItem.publish_date).toISOString().slice(0, 16) : ''
     });
     setIsEditDialogOpen(true);
   };
@@ -591,7 +589,7 @@ const NewsManagement: React.FC = () => {
                       <TableCell>
                         <div className="flex items-center text-sm text-muted-foreground">
                           <Calendar className="w-4 h-4 mr-1" />
-                          {format(new Date(newsItem.created_at), 'dd/MM/yyyy', { locale: ptBR })}
+                          {new Date(newsItem.created_at).toLocaleDateString('pt-BR')}
                         </div>
                       </TableCell>
                       <TableCell>
@@ -725,7 +723,7 @@ const NewsManagement: React.FC = () => {
                 <div className="flex items-center space-x-4 mt-2 text-sm text-muted-foreground">
                   <span>Por {selectedNews.author?.name}</span>
                   <span>•</span>
-                  <span>{format(new Date(selectedNews.created_at), 'dd/MM/yyyy HH:mm', { locale: ptBR })}</span>
+                  <span>{new Date(selectedNews.created_at).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })}</span>
                   <span>•</span>
                   <Badge variant="outline">{selectedNews.category}</Badge>
                   <span>•</span>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,31 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
-import path from 'path'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(async () => {
+  const plugins = [react()];
+
+  if (process.env.ANALYZE) {
+    try {
+      const { default: analyze } = await import('vite-bundle-analyzer');
+      plugins.push(analyze());
+    } catch (e) {
+      console.warn('vite-bundle-analyzer not installed');
+    }
+  }
+
+  return {
+    plugins,
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  server: {
-    port: 5173,
-    host: true,
-  },
-})
+    server: {
+      port: 5173,
+      host: true,
+    },
+  };
+});
+


### PR DESCRIPTION
## Summary
- add build:analyze with vite-bundle-analyzer
- lazy load heavy pages and utilities
- replace date-fns with native Date helpers

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run test:run` *(fails: module mocking and assertion errors)*
- `npm run build:analyze` *(passes with warning: vite-bundle-analyzer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a86b7aa5848333b5529f9928493d72