### PR TITLE
feat: add news services and adapters

### DIFF
--- a/src/adapters/newsAdapter.ts
+++ b/src/adapters/newsAdapter.ts
@@ -1,0 +1,46 @@
+import { NewsArticle, NewsCategory, NewsImage } from '@/shared/types/news';
+
+export interface SupabaseNewsRow {
+  id: string;
+  title: string;
+  summary?: string;
+  content: string;
+  category: string;
+  tags?: string[];
+  featured_image?: string;
+  publish_date?: string;
+  created_at?: string;
+  author?: string;
+  views?: number;
+}
+
+/**
+ * Transforms a Supabase row into a NewsArticle.
+ */
+export const toNewsArticle = (row: SupabaseNewsRow): NewsArticle => {
+  const image: NewsImage = {
+    src: row.featured_image || '',
+    alt: row.title,
+    caption: row.summary || '',
+  };
+
+  return {
+    id: row.id,
+    title: row.title,
+    excerpt: row.summary || '',
+    content: row.content,
+    category: row.category as NewsCategory,
+    date: row.publish_date || row.created_at || '',
+    tags: row.tags || [],
+    image,
+    readTime: Math.ceil((row.content?.split(/\s+/).length || 0) / 200),
+    featured: false,
+    author: row.author,
+    views: row.views,
+  };
+};
+
+export const toNewsArticleArray = (rows: SupabaseNewsRow[] = []): NewsArticle[] =>
+  rows.map(toNewsArticle);
+
+export type { NewsArticle } from '@/shared/types/news';

--- a/src/hooks/useAdvancedSearch.ts
+++ b/src/hooks/useAdvancedSearch.ts
@@ -1,25 +1,12 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { announceToScreenReader } from '@/utils/accessibility';
-import { supabase } from '@/lib/supabaseClient';
+import { searchNews, SearchResult } from '@/services/newsApi';
 
 interface SearchFilter {
   id: string;
   label: string;
   value: string;
   type: 'category' | 'date' | 'author' | 'tag';
-}
-
-interface SearchResult {
-  id: string;
-  title: string;
-  summary: string;
-  category: string;
-  author: string;
-  publishedAt: string;
-  imageUrl?: string;
-  tags: string[];
-  readTime: number;
-  views: number;
 }
 
 interface SearchState {
@@ -126,17 +113,7 @@ export const useAdvancedSearch = (options: UseAdvancedSearchOptions = {}) => {
         const author = filters.find(f => f.type === 'author')?.value;
         const tags = filters.filter(f => f.type === 'tag').map(f => f.value);
 
-        const { data, error } = await supabase.rpc('search_news', {
-          term: query,
-          category,
-          date_range,
-          author,
-          tags
-        });
-
-        if (error) throw error;
-
-        const results = (data ?? []) as SearchResult[];
+        const results = await searchNews({ term: query, category, date_range, author, tags });
         const hasMore = results.length === pageSize;
 
         setSearchState(prev => ({

--- a/src/hooks/useNewsByCategory.ts
+++ b/src/hooks/useNewsByCategory.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { NewsArticle } from '@/shared/types/news';
+import { fetchNewsByCategory } from '@/services/newsApi';
+
+interface CategoryState {
+  [key: string]: NewsArticle[];
+}
+interface LoadingState {
+  [key: string]: boolean;
+}
+interface ErrorState {
+  [key: string]: string | null;
+}
+
+export const useNewsByCategory = () => {
+  const [newsByCategory, setNewsByCategory] = useState<CategoryState>({});
+  const [loading, setLoading] = useState<LoadingState>({});
+  const [error, setError] = useState<ErrorState>({});
+
+  const loadCategory = async (category: string) => {
+    setLoading(prev => ({ ...prev, [category]: true }));
+    setError(prev => ({ ...prev, [category]: null }));
+    try {
+      const items = await fetchNewsByCategory(category);
+      setNewsByCategory(prev => ({ ...prev, [category]: items }));
+      return items;
+    } catch (err) {
+      setError(prev => ({ ...prev, [category]: (err as Error).message }));
+      return [];
+    } finally {
+      setLoading(prev => ({ ...prev, [category]: false }));
+    }
+  };
+
+  return { newsByCategory, loading, error, loadCategory };
+};

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -6,8 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { supabase } from '@/lib/supabaseClient';
-import { NewsArticle } from '@/shared/types/news';
+import { useNewsByCategory } from '@/hooks/useNewsByCategory';
 import { Newspaper, TrendingUp, MapPin, Users, Building, Heart, Leaf, Car, GraduationCap, AlertTriangle } from 'lucide-react';
 
 interface Category {
@@ -94,31 +93,12 @@ const categories: Category[] = [
 
 const Categories: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-  const [newsByCategory, setNewsByCategory] = useState<Record<string, NewsArticle[]>>({});
-  const [loadingCategories, setLoadingCategories] = useState<Record<string, boolean>>({});
-  const [errorCategories, setErrorCategories] = useState<Record<string, string | null>>({});
-
-  const fetchNews = async (categoryId: string) => {
-    setLoadingCategories(prev => ({ ...prev, [categoryId]: true }));
-    setErrorCategories(prev => ({ ...prev, [categoryId]: null }));
-    const { data, error } = await supabase
-      .from('admin_news')
-      .select('*')
-      .eq('category', categoryId);
-
-    if (error) {
-      setErrorCategories(prev => ({ ...prev, [categoryId]: error.message }));
-    } else if (data) {
-      setNewsByCategory(prev => ({ ...prev, [categoryId]: data as NewsArticle[] }));
-    }
-
-    setLoadingCategories(prev => ({ ...prev, [categoryId]: false }));
-  };
+  const { newsByCategory, loading: loadingCategories, error: errorCategories, loadCategory } = useNewsByCategory();
 
   const handleCategorySelect = (categoryId: string) => {
     setSelectedCategory(categoryId);
     if (!newsByCategory[categoryId]) {
-      fetchNews(categoryId);
+      loadCategory(categoryId);
     }
   };
 

--- a/src/services/newsApi.ts
+++ b/src/services/newsApi.ts
@@ -1,0 +1,46 @@
+import { supabase } from '@/lib/supabaseClient';
+import { NewsArticle } from '@/shared/types/news';
+import { toNewsArticleArray } from '@/adapters/newsAdapter';
+
+export const fetchNewsByCategory = async (category: string): Promise<NewsArticle[]> => {
+  const { data, error } = await supabase
+    .from('admin_news')
+    .select('*')
+    .eq('category', category)
+    .eq('status', 'published');
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return toNewsArticleArray(data as any);
+};
+
+interface SearchParams {
+  term: string;
+  category?: string;
+  date_range?: string;
+  author?: string;
+  tags?: string[];
+}
+
+export interface SearchResult {
+  id: string;
+  title: string;
+  summary: string;
+  category: string;
+  author: string;
+  publishedAt: string;
+  imageUrl?: string;
+  tags: string[];
+  readTime: number;
+  views: number;
+}
+
+export const searchNews = async (params: SearchParams): Promise<SearchResult[]> => {
+  const { data, error } = await supabase.rpc('search_news', params);
+  if (error) {
+    throw new Error(error.message);
+  }
+  return (data ?? []) as SearchResult[];
+};


### PR DESCRIPTION
## Summary
- add Supabase-backed news API service and adapter
- provide hook for loading news by category
- refactor search and categories to use typed hooks and services

## Testing
- `npm run lint` *(fails: Unexpected any in tests)*
- `npm run test:run` *(fails: useMigrationMetrics should record errors etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a86b7f96648333a6bff56fd62739a4