### PR TITLE
feat: secure input validation and sanitization

### DIFF
--- a/src/test/admin/LoginPage.test.tsx
+++ b/src/test/admin/LoginPage.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen, waitFor } from '../utils';
+import { render, screen, waitFor } from '../utils';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
 import LoginPage from '@/admin/auth/LoginPage';
 import { toast } from 'sonner';
 
@@ -25,17 +26,13 @@ describe('LoginPage', () => {
 
     render(<LoginPage />);
 
-    fireEvent.change(screen.getByLabelText(/Email/i), {
-      target: { value: 'user@example.com' }
-    });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
-      target: { value: 'senha' }
-    });
+    await userEvent.type(screen.getByLabelText(/Email/i), 'user@example.com');
+    await userEvent.type(screen.getByLabelText(/Senha/i), 'senha123');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Entrar' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Entrar' }));
 
     await waitFor(() => {
-      expect(mockLogin).toHaveBeenCalledWith('user@example.com', 'senha');
+      expect(mockLogin).toHaveBeenCalledWith('user@example.com', 'senha123');
     });
 
     expect(toast.success).toHaveBeenCalled();
@@ -47,21 +44,32 @@ describe('LoginPage', () => {
 
     render(<LoginPage />);
 
-    fireEvent.change(screen.getByLabelText(/Email/i), {
-      target: { value: 'user@example.com' }
-    });
-    fireEvent.change(screen.getByLabelText(/Senha/i), {
-      target: { value: 'errada' }
-    });
+    await userEvent.type(screen.getByLabelText(/Email/i), 'user@example.com');
+    await userEvent.type(screen.getByLabelText(/Senha/i), 'errada1');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Entrar' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Entrar' }));
 
     await waitFor(() => {
-      expect(mockLogin).toHaveBeenCalledWith('user@example.com', 'errada');
+      expect(mockLogin).toHaveBeenCalledWith('user@example.com', 'errada1');
     });
 
     expect(toast.error).toHaveBeenCalled();
     expect(screen.getByText('Credenciais inválidas')).toBeInTheDocument();
+  });
+
+  it('valida formato de email', async () => {
+    render(<LoginPage />);
+
+    await userEvent.type(screen.getByLabelText(/Email/i), 'invalid');
+    await userEvent.type(screen.getByLabelText(/Senha/i), '123456');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Entrar' }));
+
+    await waitFor(() => {
+      expect(mockLogin).not.toHaveBeenCalled();
+    });
+
+    // Validation error prevents submission
   });
 });
 

--- a/src/test/services/newsService.test.ts
+++ b/src/test/services/newsService.test.ts
@@ -51,4 +51,20 @@ describe('NewsService pagination and search', () => {
       'title.ilike.%economy%,content.ilike.%economy%'
     );
   });
+
+  it('sanitizes search term before querying', async () => {
+    mockQueryBuilder.then.mockImplementation((resolve: any) =>
+      resolve({ data: [], error: null, count: 0 })
+    );
+
+    await newsService.getPublicNews({ search: '<b>economy</b>' });
+
+    expect(mockQueryBuilder.or).toHaveBeenCalledWith(
+      'title.ilike.%economy%,content.ilike.%economy%'
+    );
+  });
+
+  it('rejeita opções inválidas', async () => {
+    await expect(newsService.getPublicNews({ limit: -1 })).rejects.toThrow();
+  });
 });

--- a/src/utils/sanitization.ts
+++ b/src/utils/sanitization.ts
@@ -1,0 +1,11 @@
+import DOMPurify from 'dompurify';
+
+export const sanitizeHtml = (content: string): string => {
+  return DOMPurify.sanitize(content);
+};
+
+export const sanitizeText = (content: string): string => {
+  return DOMPurify.sanitize(content, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
+};
+
+export default { sanitizeHtml, sanitizeText };


### PR DESCRIPTION
## Summary
- validate admin login with zod
- sanitize and validate news submissions
- guard news service options with zod

## Testing
- `npm run test:run -- src/test/admin/LoginPage.test.tsx src/test/admin/NewsForm.test.tsx src/test/services/newsService.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a86b79d4848333b2be393ff3d23e91