### PR TITLE
feat: add admin settings page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ const NewsForm = lazy(() => import("./admin/pages/NewsForm"));
 const Approvals = lazy(() => import("./admin/pages/Approvals"));
 const Reports = lazy(() => import("./admin/pages/Reports"));
 const Performance = lazy(() => import("./admin/pages/Performance"));
+const Settings = lazy(() => import("./admin/pages/Settings"));
 
 const queryClient = new QueryClient();
 
@@ -132,15 +133,23 @@ const App = () => {
                                 <Route path="/dashboard" element={<Dashboard />} />
                                 <Route path="/news" element={<NewsList />} />
                                 <Route path="/news/new" element={<NewsForm />} />
-                                <Route path="/news/edit/:id" element={<NewsForm />} />
-                                <Route path="/approvals" element={<Approvals />} />
-                                <Route path="/reports" element={<Reports />} />
-                                <Route path="/performance" element={<Performance />} />
-                                <Route path="*" element={<NotFoundLazy />} />
-                              </Routes>
-                            </AdminLayout>
-                          </Suspense>
-                        </ProtectedRoute>
+                                  <Route path="/news/edit/:id" element={<NewsForm />} />
+                                  <Route path="/approvals" element={<Approvals />} />
+                                  <Route path="/reports" element={<Reports />} />
+                                  <Route path="/performance" element={<Performance />} />
+                                  <Route
+                                    path="/settings"
+                                    element={
+                                      <ProtectedRoute requiredRole="admin">
+                                        <Settings />
+                                      </ProtectedRoute>
+                                    }
+                                  />
+                                  <Route path="*" element={<NotFoundLazy />} />
+                                </Routes>
+                              </AdminLayout>
+                            </Suspense>
+                          </ProtectedRoute>
                       </AdminProvider>
                     }
                   />

--- a/src/admin/index.ts
+++ b/src/admin/index.ts
@@ -11,6 +11,7 @@ export { default as AdminLayout } from './layout/AdminLayout';
 // Page Components
 export { default as AdminDashboard } from './pages/AdminDashboard';
 export { default as NewsManagement } from './pages/NewsManagement';
+export { default as Settings } from './pages/Settings';
 
 // Types
 export type {

--- a/src/admin/layout/AdminLayout.tsx
+++ b/src/admin/layout/AdminLayout.tsx
@@ -286,9 +286,11 @@ export const AdminLayout: React.FC = () => {
                     </div>
                   </DropdownMenuLabel>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem>
-                    <Settings className="mr-2 h-4 w-4" />
-                    Configurações
+                  <DropdownMenuItem asChild>
+                    <Link to="/admin/settings" className="flex items-center">
+                      <Settings className="mr-2 h-4 w-4" />
+                      Configurações
+                    </Link>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={handleLogout} className="text-red-600">

--- a/src/admin/pages/Settings.tsx
+++ b/src/admin/pages/Settings.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from 'react';
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '../../components/ui/card';
+import { Input } from '../../components/ui/input';
+import { Label } from '../../components/ui/label';
+import { Switch } from '../../components/ui/switch';
+import { Button } from '../../components/ui/button';
+import { supabase } from '@/lib/supabaseClient';
+import { toast } from 'sonner';
+
+const settingsSchema = z.object({
+  siteName: z.string().min(1, 'Nome do site é obrigatório'),
+  logoUrl: z.string().url('URL inválida').optional().or(z.literal('')),
+  enableComments: z.boolean(),
+  enableBeta: z.boolean(),
+});
+
+type SettingsForm = z.infer<typeof settingsSchema>;
+
+const Settings: React.FC = () => {
+  const [settingsId, setSettingsId] = useState<string | null>(null);
+  const { register, handleSubmit, setValue, watch, formState: { errors, isSubmitting } } = useForm<SettingsForm>({
+    resolver: zodResolver(settingsSchema),
+    defaultValues: {
+      siteName: '',
+      logoUrl: '',
+      enableComments: true,
+      enableBeta: false,
+    },
+  });
+
+  useEffect(() => {
+    const loadSettings = async () => {
+      const { data, error } = await supabase
+        .from('site_settings')
+        .select('*')
+        .single();
+      if (error) {
+        toast.error('Erro ao carregar configurações');
+        return;
+      }
+      if (data) {
+        setSettingsId(data.id);
+        setValue('siteName', data.site_name);
+        setValue('logoUrl', data.logo_url || '');
+        const flags = (data.feature_flags as Record<string, any>) || {};
+        setValue('enableComments', flags.enableComments ?? true);
+        setValue('enableBeta', flags.enableBeta ?? false);
+      }
+    };
+    loadSettings();
+  }, [setValue]);
+
+  const onSubmit = async (values: SettingsForm) => {
+    const { error } = await supabase.from('site_settings').upsert({
+      id: settingsId ?? undefined,
+      site_name: values.siteName,
+      logo_url: values.logoUrl || null,
+      feature_flags: {
+        enableComments: values.enableComments,
+        enableBeta: values.enableBeta,
+      },
+    });
+    if (error) {
+      toast.error('Erro ao salvar configurações');
+    } else {
+      toast.success('Configurações salvas com sucesso');
+    }
+  };
+
+  return (
+    <Card className="max-w-2xl">
+      <CardHeader>
+        <CardTitle>Configurações do Site</CardTitle>
+      </CardHeader>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <CardContent className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="siteName">Nome do Site</Label>
+            <Input id="siteName" {...register('siteName')} />
+            {errors.siteName && (
+              <p className="text-sm text-red-600">{errors.siteName.message}</p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="logoUrl">URL do Logo</Label>
+            <Input id="logoUrl" {...register('logoUrl')} />
+            {errors.logoUrl && (
+              <p className="text-sm text-red-600">{errors.logoUrl.message}</p>
+            )}
+          </div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="enableComments" className="mr-4">Habilitar comentários</Label>
+            <Switch
+              id="enableComments"
+              checked={watch('enableComments')}
+              onCheckedChange={(checked) => setValue('enableComments', checked)}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="enableBeta" className="mr-4">Habilitar recursos beta</Label>
+            <Switch
+              id="enableBeta"
+              checked={watch('enableBeta')}
+              onCheckedChange={(checked) => setValue('enableBeta', checked)}
+            />
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Button type="submit" disabled={isSubmitting}>
+            Salvar
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+};
+
+export default Settings;
+

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -185,6 +185,32 @@ export type Database = {
           created_at?: string;
         };
       };
+      site_settings: {
+        Row: {
+          id: string;
+          site_name: string;
+          logo_url: string | null;
+          feature_flags: Record<string, any>;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          site_name: string;
+          logo_url?: string | null;
+          feature_flags?: Record<string, any>;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          site_name?: string;
+          logo_url?: string | null;
+          feature_flags?: Record<string, any>;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
       web_vitals: {
         Row: {
           id: string;

--- a/supabase/migrations/012_create_site_settings_table.sql
+++ b/supabase/migrations/012_create_site_settings_table.sql
@@ -1,0 +1,36 @@
+-- Tabela para armazenar configurações globais do site
+CREATE TABLE IF NOT EXISTS site_settings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    site_name TEXT NOT NULL,
+    logo_url TEXT,
+    feature_flags JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Trigger para atualizar updated_at
+CREATE TRIGGER update_site_settings_updated_at
+    BEFORE UPDATE ON site_settings
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Habilitar RLS
+ALTER TABLE site_settings ENABLE ROW LEVEL SECURITY;
+
+-- Políticas: apenas administradores podem gerenciar configurações
+CREATE POLICY "Admins can manage site settings" ON site_settings
+    FOR ALL USING (
+        EXISTS (
+            SELECT 1 FROM admin_users
+            WHERE id = auth.uid() AND role = 'admin' AND is_active = true
+        )
+    ) WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM admin_users
+            WHERE id = auth.uid() AND role = 'admin' AND is_active = true
+        )
+    );
+
+-- Registro padrão
+INSERT INTO site_settings (site_name, logo_url, feature_flags)
+VALUES ('UbaNews', NULL, '{}'::jsonb)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- add site-wide settings page with Supabase persistence and validation
- protect settings route for admins and link it in navigation
- define site_settings table and types

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8d38d16c83339a044339b553cff0