### PR TITLE
feat: add admin users management page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ const NewsForm = lazy(() => import("./admin/pages/NewsForm"));
 const Approvals = lazy(() => import("./admin/pages/Approvals"));
 const Reports = lazy(() => import("./admin/pages/Reports"));
 const Performance = lazy(() => import("./admin/pages/Performance"));
+const Users = lazy(() => import("./admin/pages/Users"));
 
 const queryClient = new QueryClient();
 
@@ -136,6 +137,14 @@ const App = () => {
                                 <Route path="/approvals" element={<Approvals />} />
                                 <Route path="/reports" element={<Reports />} />
                                 <Route path="/performance" element={<Performance />} />
+                                <Route
+                                  path="/users"
+                                  element={
+                                    <ProtectedRoute requiredRole="admin">
+                                      <Users />
+                                    </ProtectedRoute>
+                                  }
+                                />
                                 <Route path="*" element={<NotFoundLazy />} />
                               </Routes>
                             </AdminLayout>

--- a/src/admin/pages/Users.tsx
+++ b/src/admin/pages/Users.tsx
@@ -1,0 +1,290 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
+import { Button } from '../../components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from '../../components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '../../components/ui/dialog';
+import { Input } from '../../components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '../../components/ui/select';
+import { Badge } from '../../components/ui/badge';
+import { Plus, Edit, Trash2 } from 'lucide-react';
+import { supabase } from '@/lib/supabaseClient';
+import { toast } from 'sonner';
+import { useAdmin } from '../context/AdminProvider';
+
+interface AdminUser {
+  id: string;
+  email: string;
+  full_name: string;
+  role: 'admin' | 'editor' | 'columnist';
+  is_active: boolean;
+}
+
+export const Users: React.FC = () => {
+  const { user: currentUser } = useAdmin();
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editingUser, setEditingUser] = useState<AdminUser | null>(null);
+  const [formData, setFormData] = useState({
+    email: '',
+    full_name: '',
+    role: 'editor' as 'admin' | 'editor' | 'columnist'
+  });
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  const loadUsers = async () => {
+    try {
+      setLoading(true);
+      const { data, error } = await supabase
+        .from('admin_users')
+        .select('*')
+        .order('created_at', { ascending: false });
+      if (error) throw error;
+      setUsers(data || []);
+    } catch (error) {
+      console.error('Error loading users:', error);
+      toast.error('Erro ao carregar usuários');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreate = async () => {
+    try {
+      const { error } = await supabase.from('admin_users').insert({
+        email: formData.email,
+        full_name: formData.full_name,
+        role: formData.role,
+        is_active: true
+      });
+      if (error) throw error;
+      toast.success('Usuário criado com sucesso');
+      setCreateOpen(false);
+      setFormData({ email: '', full_name: '', role: 'editor' });
+      loadUsers();
+    } catch (error) {
+      console.error('Error creating user:', error);
+      toast.error('Erro ao criar usuário');
+    }
+  };
+
+  const openEdit = (u: AdminUser) => {
+    setEditingUser(u);
+    setFormData({ email: u.email, full_name: u.full_name, role: u.role });
+    setEditOpen(true);
+  };
+
+  const handleEdit = async () => {
+    if (!editingUser) return;
+    try {
+      const { error } = await supabase
+        .from('admin_users')
+        .update({ full_name: formData.full_name, role: formData.role })
+        .eq('id', editingUser.id);
+      if (error) throw error;
+      toast.success('Usuário atualizado');
+      setEditOpen(false);
+      setEditingUser(null);
+      loadUsers();
+    } catch (error) {
+      console.error('Error updating user:', error);
+      toast.error('Erro ao atualizar usuário');
+    }
+  };
+
+  const handleDeactivate = async (u: AdminUser) => {
+    try {
+      const { error } = await supabase
+        .from('admin_users')
+        .update({ is_active: false })
+        .eq('id', u.id);
+      if (error) throw error;
+      toast.success('Usuário desativado');
+      if (u.id === currentUser?.id) {
+        // Optional: handle deactivating current user
+      }
+      loadUsers();
+    } catch (error) {
+      console.error('Error deactivating user:', error);
+      toast.error('Erro ao desativar usuário');
+    }
+  };
+
+  const renderRoleBadge = (role: string) => {
+    const colors = {
+      admin: 'bg-red-100 text-red-800',
+      editor: 'bg-blue-100 text-blue-800',
+      columnist: 'bg-green-100 text-green-800'
+    } as const;
+    const color = (colors as any)[role] || 'bg-gray-100 text-gray-800';
+    return <Badge className={color}>{role}</Badge>;
+  };
+
+  return (
+    <div className="p-4 md:p-6">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Gestão de Usuários</CardTitle>
+            <CardDescription>
+              Gerencie os usuários administradores da plataforma
+            </CardDescription>
+          </div>
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="w-4 h-4 mr-2" /> Novo Usuário
+          </Button>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nome</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead>Função</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Ações</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users.map((u) => (
+                <TableRow key={u.id}>
+                  <TableCell>{u.full_name}</TableCell>
+                  <TableCell>{u.email}</TableCell>
+                  <TableCell>{renderRoleBadge(u.role)}</TableCell>
+                  <TableCell>
+                    {u.is_active ? (
+                      <Badge className="bg-green-100 text-green-800">Ativo</Badge>
+                    ) : (
+                      <Badge className="bg-gray-100 text-gray-800">Inativo</Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right space-x-2">
+                    <Button size="sm" variant="outline" onClick={() => openEdit(u)}>
+                      <Edit className="w-4 h-4" />
+                    </Button>
+                    <Button size="sm" variant="destructive" onClick={() => handleDeactivate(u)}>
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {!loading && users.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+                    Nenhum usuário encontrado
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* Create Dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Novo Usuário</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <Input
+              placeholder="Nome completo"
+              value={formData.full_name}
+              onChange={(e) => setFormData({ ...formData, full_name: e.target.value })}
+            />
+            <Input
+              placeholder="Email"
+              type="email"
+              value={formData.email}
+              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+            />
+            <Select
+              value={formData.role}
+              onValueChange={(value) =>
+                setFormData({ ...formData, role: value as 'admin' | 'editor' | 'columnist' })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Selecione o papel" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="admin">Administrador</SelectItem>
+                <SelectItem value="editor">Editor</SelectItem>
+                <SelectItem value="columnist">Colunista</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>
+              Cancelar
+            </Button>
+            <Button onClick={handleCreate}>Criar</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Editar Usuário</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <Input
+              placeholder="Nome completo"
+              value={formData.full_name}
+              onChange={(e) => setFormData({ ...formData, full_name: e.target.value })}
+            />
+            <Select
+              value={formData.role}
+              onValueChange={(value) =>
+                setFormData({ ...formData, role: value as 'admin' | 'editor' | 'columnist' })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Selecione o papel" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="admin">Administrador</SelectItem>
+                <SelectItem value="editor">Editor</SelectItem>
+                <SelectItem value="columnist">Colunista</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditOpen(false)}>
+              Cancelar
+            </Button>
+            <Button onClick={handleEdit}>Salvar</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default Users;
+

--- a/src/test/admin/Users.test.tsx
+++ b/src/test/admin/Users.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Users } from '@/admin/pages/Users';
+import ProtectedRoute from '@/admin/auth/ProtectedRoute';
+import { useAdmin } from '@/admin/context/AdminProvider';
+
+vi.mock('@/admin/context/AdminProvider', () => ({
+  useAdmin: vi.fn()
+}));
+
+const mockedUseAdmin = useAdmin as unknown as ReturnType<typeof vi.fn>;
+
+const selectMock = vi.fn().mockResolvedValue({ data: [], error: null });
+const fromMock = vi.fn(() => ({ select: selectMock }));
+vi.mock('@/lib/supabaseClient', () => ({
+  supabase: { from: fromMock }
+}));
+
+const renderUsersRoute = () =>
+  render(
+    <MemoryRouter initialEntries={['/admin/users']}>
+      <Routes>
+        <Route
+          path="/admin/users"
+          element={
+            <ProtectedRoute requiredRole="admin">
+              <Users />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="/admin/login" element={<div>Página de Login</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('Users page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('permite acesso para administradores', async () => {
+    mockedUseAdmin.mockReturnValue({
+      user: { role: 'admin' },
+      loading: false,
+      logout: vi.fn()
+    });
+    renderUsersRoute();
+    expect(fromMock).toHaveBeenCalledWith('admin_users');
+    await waitFor(() => {
+      expect(screen.getByText('Gestão de Usuários')).toBeInTheDocument();
+    });
+  });
+
+  it('bloqueia acesso para usuários não administradores', () => {
+    mockedUseAdmin.mockReturnValue({
+      user: { role: 'editor' },
+      loading: false,
+      logout: vi.fn()
+    });
+    renderUsersRoute();
+    expect(screen.getByText('Acesso Negado')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Users management page with create/edit/deactivate actions
- secure admin users route with ProtectedRoute requiring admin role
- add route integration and unit tests

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8d3644ac8333b718409e3c909e83