### PR TITLE
refactor: update permission api

### DIFF
--- a/src/admin/context/AdminProvider.tsx
+++ b/src/admin/context/AdminProvider.tsx
@@ -25,7 +25,7 @@ interface AdminContextType {
     otp?: string
   ) => Promise<{ success: boolean; error?: string }>;
   logout: () => Promise<void>;
-  hasPermission: (permission: string) => boolean;
+  hasPermission: (resource: string, action: string) => boolean;
   hasRole: (role: string | string[]) => boolean;
   refreshUser: () => Promise<void>;
 }
@@ -251,25 +251,29 @@ export const AdminProvider: React.FC<AdminProviderProps> = ({ children }) => {
     }
   };
 
-  const hasPermission = (permission: string): boolean => {
+  const hasPermission = (resource: string, action: string): boolean => {
     if (!user) return false;
-    
+
+    const permission = `${resource}.${action}`;
+
     // Define permissions based on roles
     const rolePermissions = {
       admin: ['*'], // Admin has all permissions
       editor: [
+        'news.read',
         'news.create',
-        'news.edit',
+        'news.update',
         'news.delete',
         'news.publish',
         'news.approve',
         'dashboard.view',
-        'users.view'
+        'users.read'
       ],
       columnist: [
+        'news.read',
         'news.create',
-        'news.edit.own',
-        'dashboard.view.limited'
+        'news.update',
+        'dashboard.view'
       ]
     };
 

--- a/src/admin/layout/AdminLayout.tsx
+++ b/src/admin/layout/AdminLayout.tsx
@@ -115,8 +115,11 @@ export const AdminLayout: React.FC = () => {
     if (item.allowedRoles && !item.allowedRoles.includes(user?.role || 'columnist')) {
       return false;
     }
-    if (item.requiredPermission && !hasPermission(item.requiredPermission.resource, item.requiredPermission.action)) {
-      return false;
+    if (item.requiredPermission) {
+      const { resource, action } = item.requiredPermission;
+      if (!hasPermission(resource, action)) {
+        return false;
+      }
     }
     return true;
   });


### PR DESCRIPTION
## Summary
- expose `hasPermission(resource, action)` in AdminProvider and normalize role permissions
- adjust AdminLayout navigation filtering for new permission API

## Testing
- `npm run lint` *(fails: eslint: not found)*
- `npm run test:run` *(fails: vitest: not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8d33b9f08333b33f6b8030a988a3