### PR TITLE
feat: optimize bundle splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19",
     "storybook": "^8.4.4",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "rollup-plugin-visualizer": "^5.12.0"
   }
 }

--- a/src/admin/pages/AdminDashboard.tsx
+++ b/src/admin/pages/AdminDashboard.tsx
@@ -5,20 +5,6 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  LineChart,
-  Line,
-  PieChart,
-  Pie,
-  Cell
-} from 'recharts';
-import {
   FileText,
   Users,
   Eye,
@@ -47,6 +33,7 @@ const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8'];
 
 const AdminDashboard: React.FC = () => {
   const { user, hasPermission } = useAdmin();
+  const [recharts, setRecharts] = useState<any>(null)
   const [stats, setStats] = useState<DashboardStats>({
     totalNews: 0,
     publishedNews: 0,
@@ -66,6 +53,29 @@ const AdminDashboard: React.FC = () => {
   });
   const [loading, setLoading] = useState(true);
   const [lastUpdate, setLastUpdate] = useState<Date>(new Date());
+
+  useEffect(() => {
+    import('recharts').then(setRecharts)
+  }, [])
+
+  if (!recharts) {
+    return null
+  }
+
+  const {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer,
+    LineChart,
+    Line,
+    PieChart,
+    Pie,
+    Cell,
+  } = recharts
 
   const fetchDashboardData = async () => {
     try {

--- a/src/admin/pages/Reports.tsx
+++ b/src/admin/pages/Reports.tsx
@@ -11,22 +11,6 @@ import {
   SelectValue,
 } from '../../components/ui/select';
 import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  PieChart,
-  Pie,
-  Cell,
-  LineChart,
-  Line,
-  Area,
-  AreaChart
-} from 'recharts';
-import {
   FileText,
   TrendingUp,
   Users,
@@ -67,6 +51,7 @@ const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8'];
 
 export const Reports: React.FC = () => {
   const { user } = useAdmin();
+  const [recharts, setRecharts] = useState<any>(null);
   const [reportData, setReportData] = useState<ReportData | null>(null);
   const [loading, setLoading] = useState(true);
   const [dateRange, setDateRange] = useState('30'); // days
@@ -75,6 +60,10 @@ export const Reports: React.FC = () => {
   useEffect(() => {
     loadReportData();
   }, [dateRange]);
+
+  useEffect(() => {
+    import('recharts').then(setRecharts)
+  }, [])
 
   const loadReportData = async () => {
     try {
@@ -223,7 +212,7 @@ export const Reports: React.FC = () => {
     toast.success('Relatório exportado com sucesso');
   };
 
-  if (loading) {
+  if (loading || !recharts) {
     return (
       <div className="space-y-6">
         <div className="h-20 bg-gray-200 rounded-lg animate-pulse" />
@@ -255,6 +244,22 @@ export const Reports: React.FC = () => {
       </div>
     );
   }
+  const {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer,
+    PieChart,
+    Pie,
+    Cell,
+    LineChart,
+    Line,
+    Area,
+    AreaChart,
+  } = recharts
 
   return (
     <div className="space-y-6">

--- a/src/components/ui/live-alert.tsx
+++ b/src/components/ui/live-alert.tsx
@@ -1,6 +1,6 @@
 import { Alert, AlertDescription } from "@/components/ui/alert"
-import { AnimatePresence, motion } from "framer-motion"
 import { CheckCircle, AlertCircle } from "lucide-react"
+import React from "react"
 
 interface LiveAlertProps {
   message: string
@@ -8,6 +8,16 @@ interface LiveAlertProps {
 }
 
 export function LiveAlert({ message, type }: LiveAlertProps) {
+  const [fm, setFm] = React.useState<any>(null)
+
+  React.useEffect(() => {
+    import("framer-motion").then(setFm)
+  }, [])
+
+  if (!fm) return null
+
+  const { AnimatePresence, motion } = fm
+
   return (
     <AnimatePresence>
       {type && (

--- a/src/components/ui/rich-text-editor.tsx
+++ b/src/components/ui/rich-text-editor.tsx
@@ -1,6 +1,4 @@
-import React, { useEffect } from 'react'
-import { EditorContent, useEditor } from '@tiptap/react'
-import StarterKit from '@tiptap/starter-kit'
+import React, { useEffect, useState } from 'react'
 import { cn } from '@/lib/utils'
 
 interface RichTextEditorProps {
@@ -10,12 +8,22 @@ interface RichTextEditorProps {
 }
 
 export const RichTextEditor: React.FC<RichTextEditorProps> = ({ value = '', onChange, className }) => {
-  const editor = useEditor({
-    extensions: [StarterKit],
+  const [tiptap, setTiptap] = useState<any>(null)
+
+  useEffect(() => {
+    Promise.all([import('@tiptap/react'), import('@tiptap/starter-kit')]).then(
+      ([react, starter]) => {
+        setTiptap({ ...react, StarterKit: starter.default })
+      }
+    )
+  }, [])
+
+  const editor = tiptap?.useEditor({
+    extensions: [tiptap.StarterKit],
     content: value,
-    onUpdate({ editor }) {
+    onUpdate({ editor }: any) {
       onChange?.(editor.getHTML())
-    }
+    },
   })
 
   useEffect(() => {
@@ -23,6 +31,10 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({ value = '', onCh
       editor.commands.setContent(value)
     }
   }, [editor, value])
+
+  if (!tiptap || !editor) return null
+
+  const EditorContent = tiptap.EditorContent
 
   return (
     <div
@@ -37,3 +49,4 @@ export const RichTextEditor: React.FC<RichTextEditorProps> = ({ value = '', onCh
 }
 
 export default RichTextEditor
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import path from 'path'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), visualizer({ filename: 'stats.html', gzipSize: true, brotliSize: true })],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
@@ -13,5 +14,19 @@ export default defineConfig({
   server: {
     port: 5173,
     host: true,
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            return 'vendor'
+          }
+          if (id.includes('src/admin')) {
+            return 'admin'
+          }
+        },
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- add rollup-plugin-visualizer and manual chunking for vendor/admin bundles
- lazy load heavy libs (framer-motion, tiptap, recharts) with dynamic imports

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b23c948d0c8333a55060dba25de477