### PR TITLE
test: add integration and e2e setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm install
+      - run: npm run lint
+      - run: npm test
+      - run: npx playwright install --with-deps
+      - run: npm run build
+      - run: npm run test:e2e

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest --watch",
     "check": "npm run lint && npm run test:run",
+    "test:e2e": "npx playwright test",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  use: {
+    baseURL: 'http://localhost:4173',
+    headless: true,
+  },
+  webServer: {
+    command: 'npm run preview',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/src/__tests__/newsService.integration.test.ts
+++ b/src/__tests__/newsService.integration.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import newsService from '@/services/newsService';
+
+// Integration tests for NewsService without external dependencies
+
+describe('NewsService integration', () => {
+  beforeEach(() => {
+    newsService.clearCache();
+    newsService.setDynamicMode(false); // use static data
+  });
+
+  it('returns static articles when dynamic mode disabled', async () => {
+    const result = await newsService.getPublicNews({ limit: 2 });
+    expect(result.success).toBe(true);
+    expect(result.data.length).toBeGreaterThan(0);
+  });
+
+  it('caches repeated calls', async () => {
+    await newsService.getPublicNews({ limit: 1 });
+    const statsBefore = newsService.getStats();
+    await newsService.getPublicNews({ limit: 1 });
+    const statsAfter = newsService.getStats();
+    expect(statsAfter.cacheHits).toBeGreaterThan(statsBefore.cacheHits);
+  });
+});

--- a/src/__tests__/usePublicNews.integration.test.tsx
+++ b/src/__tests__/usePublicNews.integration.test.tsx
@@ -1,0 +1,34 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePublicNews } from '@/hooks/usePublicNews';
+import newsService from '@/services/newsService';
+
+// Wrapper with React Query provider
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe('usePublicNews integration', () => {
+  beforeEach(() => {
+    newsService.clearCache();
+    newsService.setDynamicMode(false); // use static data
+  });
+
+  it('fetches news via service and exposes data', async () => {
+    const { result } = renderHook(() => usePublicNews(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data.length).toBeGreaterThan(0);
+    });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('home page displays main content', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#main-content')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add integration tests for news service and public news hook
- configure Playwright and GitHub Actions CI pipeline

## Testing
- `npm test` *(fails: vitest not found)*
- `npx playwright test` *(fails: Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68b23ca20188833387d753bb0b173abb