### PR TITLE
chore: add environment validation

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,0 +1,8 @@
+# Environment variables required for the application
+# Supabase configuration
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+
+# Optional fallbacks used in tests
+REACT_APP_SUPABASE_URL=
+REACT_APP_SUPABASE_ANON_KEY=

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']),
+  VITE_SUPABASE_URL: z.string().url(),
+  VITE_SUPABASE_ANON_KEY: z.string(),
+  REACT_APP_SUPABASE_URL: z.string().url().optional(),
+  REACT_APP_SUPABASE_ANON_KEY: z.string().optional(),
+});
+
+export const env = envSchema.parse({
+  NODE_ENV: process.env.NODE_ENV,
+  VITE_SUPABASE_URL: import.meta.env.VITE_SUPABASE_URL,
+  VITE_SUPABASE_ANON_KEY: import.meta.env.VITE_SUPABASE_ANON_KEY,
+  REACT_APP_SUPABASE_URL: process.env.REACT_APP_SUPABASE_URL,
+  REACT_APP_SUPABASE_ANON_KEY: process.env.REACT_APP_SUPABASE_ANON_KEY,
+});
+
+export type Env = z.infer<typeof envSchema>;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import './config/env';
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
## Summary
- validate required environment variables with zod
- run validation before bootstrapping React
- document required env vars in env.example

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:run` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b23c93cb0483339a7586570b323aa2